### PR TITLE
Updated react-teams web part to display web part title like OOTB

### DIFF
--- a/samples/react-teams-message/src/webparts/myTeams/MyTeamsWebPart.ts
+++ b/samples/react-teams-message/src/webparts/myTeams/MyTeamsWebPart.ts
@@ -27,7 +27,11 @@ export default class MyTeamsWebPart extends BaseClientSideWebPart <IMyTeamsWebPa
         context: this.context,
         webparttitle:this.properties.WebpartTitle,
         showdescription:this.properties.ShowDescription,
-        openpopuponselectingchannel:this.properties.OpenPopupOnSelectingChannel
+        openpopuponselectingchannel:this.properties.OpenPopupOnSelectingChannel,
+        displayMode: this.displayMode,
+        updateProperty: (value: string) => {
+          this.properties.WebpartTitle = value;
+        }
       }
     );
 

--- a/samples/react-teams-message/src/webparts/myTeams/components/IMyTeamsProps.ts
+++ b/samples/react-teams-message/src/webparts/myTeams/components/IMyTeamsProps.ts
@@ -1,8 +1,10 @@
 import { WebPartContext } from "@microsoft/sp-webpart-base";
-
+import { DisplayMode } from "@microsoft/sp-core-library";
 export interface IMyTeamsProps {
   context: WebPartContext;
   webparttitle: string;
   showdescription:boolean;
   openpopuponselectingchannel:boolean;
+  displayMode:DisplayMode;
+  updateProperty:(value: string) => void;
 }

--- a/samples/react-teams-message/src/webparts/myTeams/components/MyTeams.tsx
+++ b/samples/react-teams-message/src/webparts/myTeams/components/MyTeams.tsx
@@ -6,6 +6,7 @@ import { ServiceProvider } from '../../../shared/services/ServiceProvider';
 import { TreeView, ITreeItem, TreeItemActionsDisplayMode, TreeViewSelectionMode } from "@pnp/spfx-controls-react/lib/TreeView";
 import { PrimaryButton, DefaultButton, Dialog, DialogFooter, DialogType, TextField, MessageBar,MessageBarType } from 'office-ui-fabric-react';
 import { initializeIcons } from '@uifabric/icons';
+import { WebPartTitle } from "@pnp/spfx-controls-react/lib/WebPartTitle";
 
 export interface IMyTeamsState {
   myteams: any[];
@@ -127,9 +128,13 @@ export default class MyTeams extends React.Component<IMyTeamsProps, IMyTeamsStat
       <React.Fragment>
         <div className={styles.myTeams}>
           <i className="ms-Icon ms-Icon--TeamsLogo" aria-hidden="true"></i>
-          <h1 className={styles.webpartitle}>
+          {/* <h1 className={styles.webpartitle}>
 
-            {this.props.webparttitle}</h1>
+            {this.props.webparttitle}</h1> */}
+
+            <WebPartTitle displayMode={this.props.displayMode}
+              title={this.props.webparttitle}
+              updateProperty={this.props.updateProperty} />
            
           {this.state.showMessage &&
           <React.Fragment>


### PR DESCRIPTION
|        Q        |                    A                    |
| --------------- | --------------------------------------- |
| New feature?    | yes                               |

## What's in this Pull Request?

Updated react-teams web part to display Web part title like OOTB web parts.

![image](https://user-images.githubusercontent.com/9557557/83336425-e8bfc280-a2d0-11ea-8de7-44246e2b61fb.png)

