### PR TITLE
fixed path to WordGameListItem

### DIFF
--- a/samples/react-word-game/src/webparts/wordGame/components/WordGame.tsx
+++ b/samples/react-word-game/src/webparts/wordGame/components/WordGame.tsx
@@ -1,9 +1,8 @@
 import * as React from 'react';
 import styles from './WordGame.module.scss';
 import { IWordGameProps, IWordGameState } from './IWordGameProps';
-import { WordService, Game } from './WordService';
+import { WordService, Game, WordGameListItem } from './WordService';
 import WordHighScores from './WordHighScores';
-import { WordGameListItem } from '../../../../lib/webparts/wordGame/components/WordService';
 
 // tslint:disable-next-line: no-any
 const logo: any = require('../assets/ajax-loader.gif');


### PR DESCRIPTION
|        Q        |                    A                    |
| --------------- | --------------------------------------- |
| Bug fix?        | yes                               |
| New feature?    | no                               |
| New sample?     | no                               |

## What's in this Pull Request?

Fixed path to WordGameListItem in WordGame, otherwise Gulp Serve was failing on the first build because the Lib folder was not yet generated.
