### PR TITLE
Correct URL from dev.office.com

### DIFF
--- a/samples/react-bot-framework/README.md
+++ b/samples/react-bot-framework/README.md
@@ -33,8 +33,8 @@ where sample was demonstrated.
 
 ## Applies to
 
-* [SharePoint Framework Developer](http://dev.office.com/sharepoint/docs/spfx/sharepoint-framework-overview)
-* [Office 365 developer tenant](http://dev.office.com/sharepoint/docs/spfx/set-up-your-developer-tenant)
+* [SharePoint Framework Developer](https://docs.microsoft.com/en-us/sharepoint/dev/spfx/sharepoint-framework-overview)
+* [Office 365 developer tenant](https://docs.microsoft.com/en-us/sharepoint/dev/spfx/set-up-your-developer-tenant)
 * [Microsoft Bot Framework](http://dev.botframework.com)
 
 ## Prerequisites


### PR DESCRIPTION
Correct URL from dev.office.com to docs.microsoft.com
* SharePoint Framework Developer
* Office 365 developer tenant

|        Q        |                    A                    |
| --------------- | --------------------------------------- |
| Related issues? | fixes #1305  |




