### PR TITLE
Fix paging implementation

### DIFF
--- a/samples/react-accordion/src/webparts/reactAccordion/components/IReactAccordionState.ts
+++ b/samples/react-accordion/src/webparts/reactAccordion/components/IReactAccordionState.ts
@@ -2,6 +2,7 @@ import IAccordionListItem from '../models/IAccordionListItem';
 
 export interface IReactAccordionState {
   status: string;
+  pagedItems: IAccordionListItem[];
   items: IAccordionListItem[];
   listItems: IAccordionListItem[];
   isLoading: boolean;

--- a/samples/react-accordion/src/webparts/reactAccordion/components/ReactAccordion.tsx
+++ b/samples/react-accordion/src/webparts/reactAccordion/components/ReactAccordion.tsx
@@ -53,7 +53,10 @@ export default class ReactAccordion extends React.Component<IReactAccordionProps
       event === null ||
       event === "") {
       let listItemsCollection = [...this.state.listItems];
-      this.setState({ pagedItems: listItemsCollection.splice(0, this.props.maxItemsPerPage) });
+      this.setState({
+        items: listItemsCollection,
+        pagedItems: listItemsCollection.slice(0, this.props.maxItemsPerPage)
+      });
     }
     else {
       var updatedList = [...this.state.listItems];
@@ -62,7 +65,10 @@ export default class ReactAccordion extends React.Component<IReactAccordionProps
           event.toLowerCase()) !== -1 || item.Description.toLowerCase().search(
             event.toLowerCase()) !== -1;
       });
-      this.setState({ items: updatedList });
+      this.setState({
+        items: updatedList,
+        pagedItems: updatedList.slice(0, this.props.maxItemsPerPage)
+      });
     }
   }
 

--- a/samples/react-accordion/src/webparts/reactAccordion/components/ReactAccordion.tsx
+++ b/samples/react-accordion/src/webparts/reactAccordion/components/ReactAccordion.tsx
@@ -26,6 +26,7 @@ export default class ReactAccordion extends React.Component<IReactAccordionProps
     super(props);
     this.state = {
       status: this.listNotConfigured(this.props) ? 'Please configure list in Web Part properties' : 'Ready',
+      pagedItems: [],
       items: [],
       listItems: [],
       isLoading: false,

--- a/samples/react-accordion/src/webparts/reactAccordion/components/ReactAccordion.tsx
+++ b/samples/react-accordion/src/webparts/reactAccordion/components/ReactAccordion.tsx
@@ -100,7 +100,6 @@ export default class ReactAccordion extends React.Component<IReactAccordionProps
         this.setState({
           status: 'Loading all items failed with error: ' + error,
           pagedItems: [],
-          items: [],
           isLoading: false,
           loaderMessage: ""
         });
@@ -148,8 +147,8 @@ export default class ReactAccordion extends React.Component<IReactAccordionProps
       displayLoader = (null);
     }
 
-    if (this.state.items.length > 0) {
-      pageCount = Math.ceil(this.state.items.length / pageCountDivisor);
+    if (items.length > 0) {
+      pageCount = Math.ceil(items.length / pageCountDivisor);
     }
     for (let i = 0; i < pageCount; i++) {
       pageButtons.push(<PrimaryButton onClick={() => { _pagedButtonClick(i + 1, items); }}> {i + 1} </PrimaryButton>);

--- a/samples/react-accordion/src/webparts/reactAccordion/components/ReactAccordion.tsx
+++ b/samples/react-accordion/src/webparts/reactAccordion/components/ReactAccordion.tsx
@@ -105,7 +105,7 @@ export default class ReactAccordion extends React.Component<IReactAccordionProps
   public render(): React.ReactElement<IReactAccordionProps> {
     let displayLoader;
     let faqTitle;
-    let { listItems } = this.state;
+    let { items } = this.state;
     let pageCountDivisor: number = this.props.maxItemsPerPage;
     let pageCount: number;
     let pageButtons = [];
@@ -142,11 +142,11 @@ export default class ReactAccordion extends React.Component<IReactAccordionProps
       displayLoader = (null);
     }
 
-    if (this.state.listItems.length > 0) {
-      pageCount = Math.ceil(this.state.listItems.length / pageCountDivisor);
+    if (this.state.items.length > 0) {
+      pageCount = Math.ceil(this.state.items.length / pageCountDivisor);
     }
     for (let i = 0; i < pageCount; i++) {
-      pageButtons.push(<PrimaryButton onClick={() => { _pagedButtonClick(i + 1, listItems); }}> {i + 1} </PrimaryButton>);
+      pageButtons.push(<PrimaryButton onClick={() => { _pagedButtonClick(i + 1, items); }}> {i + 1} </PrimaryButton>);
     }
     return (
       <div className={styles.reactAccordion}>

--- a/samples/react-accordion/src/webparts/reactAccordion/components/ReactAccordion.tsx
+++ b/samples/react-accordion/src/webparts/reactAccordion/components/ReactAccordion.tsx
@@ -90,7 +90,7 @@ export default class ReactAccordion extends React.Component<IReactAccordionProps
 
         this.setState({
           status: "",
-          pagedItems: listItemsCollection.splice(0, this.props.maxItemsPerPage),
+          pagedItems: listItemsCollection.slice(0, this.props.maxItemsPerPage),
           items: response.value,
           listItems: response.value,
           isLoading: false,
@@ -117,8 +117,9 @@ export default class ReactAccordion extends React.Component<IReactAccordionProps
 
     let _pagedButtonClick = (pageNumber: number, listData: any) => {
       let startIndex: number = (pageNumber - 1) * pageCountDivisor;
+      let endIndex = startIndex + pageCountDivisor;
       let listItemsCollection = [...listData];
-      this.setState({ pagedItems: listItemsCollection.splice(startIndex, pageCountDivisor) });
+      this.setState({ pagedItems: listItemsCollection.slice(startIndex, endIndex) });
     };
 
     const pagedItems: JSX.Element[] = this.state.pagedItems.map((item: IAccordionListItem, i: number): JSX.Element => {

--- a/samples/react-accordion/src/webparts/reactAccordion/components/ReactAccordion.tsx
+++ b/samples/react-accordion/src/webparts/reactAccordion/components/ReactAccordion.tsx
@@ -53,7 +53,7 @@ export default class ReactAccordion extends React.Component<IReactAccordionProps
       event === null ||
       event === "") {
       let listItemsCollection = [...this.state.listItems];
-      this.setState({ items: listItemsCollection.splice(0, this.props.maxItemsPerPage) });
+      this.setState({ pagedItems: listItemsCollection.splice(0, this.props.maxItemsPerPage) });
     }
     else {
       var updatedList = [...this.state.listItems];
@@ -84,7 +84,8 @@ export default class ReactAccordion extends React.Component<IReactAccordionProps
 
         this.setState({
           status: "",
-          items: listItemsCollection.splice(0, this.props.maxItemsPerPage),
+          pagedItems: listItemsCollection.splice(0, this.props.maxItemsPerPage),
+          items: response.value,
           listItems: response.value,
           isLoading: false,
           loaderMessage: ""
@@ -92,6 +93,7 @@ export default class ReactAccordion extends React.Component<IReactAccordionProps
       }, (error: any): void => {
         this.setState({
           status: 'Loading all items failed with error: ' + error,
+          pagedItems: [],
           items: [],
           isLoading: false,
           loaderMessage: ""
@@ -111,10 +113,10 @@ export default class ReactAccordion extends React.Component<IReactAccordionProps
     let _pagedButtonClick = (pageNumber: number, listData: any) => {
       let startIndex: number = (pageNumber - 1) * pageCountDivisor;
       let listItemsCollection = [...listData];
-      this.setState({ items: listItemsCollection.splice(startIndex, pageCountDivisor) });
+      this.setState({ pagedItems: listItemsCollection.splice(startIndex, pageCountDivisor) });
     };
 
-    const items: JSX.Element[] = this.state.items.map((item: IAccordionListItem, i: number): JSX.Element => {
+    const items: JSX.Element[] = this.state.pagedItems.map((item: IAccordionListItem, i: number): JSX.Element => {
       return (
         <AccordionItem>
           <AccordionItemTitle className="accordion__title">

--- a/samples/react-accordion/src/webparts/reactAccordion/components/ReactAccordion.tsx
+++ b/samples/react-accordion/src/webparts/reactAccordion/components/ReactAccordion.tsx
@@ -116,7 +116,7 @@ export default class ReactAccordion extends React.Component<IReactAccordionProps
       this.setState({ pagedItems: listItemsCollection.splice(startIndex, pageCountDivisor) });
     };
 
-    const items: JSX.Element[] = this.state.pagedItems.map((item: IAccordionListItem, i: number): JSX.Element => {
+    const pagedItems: JSX.Element[] = this.state.pagedItems.map((item: IAccordionListItem, i: number): JSX.Element => {
       return (
         <AccordionItem>
           <AccordionItemTitle className="accordion__title">
@@ -167,7 +167,7 @@ export default class ReactAccordion extends React.Component<IReactAccordionProps
             <div className='ms-Grid-col ms-u-lg12'>
               {this.state.status}
               <Accordion accordion={false}>
-                {items}
+                {pagedItems}
               </Accordion>
             </div>
           </div>


### PR DESCRIPTION
PR for your review @gautamdsheth.

|        Q        |                    A                    |
| --------------- | --------------------------------------- |
| Bug fix?        | yes                               |
| New feature?    | no                               |
| New sample?     | no                               |
| Related issues? | fixes #1337 |

## What's in this Pull Request?
Introduced new property `pagedItems`.
Used `pagedItems` to show items on a particular page. Used property `items` to store latest list of complete results (whether on search, or on first load).
`listItems` now stores just that, i.e., the original list of items returned from the list.

