### PR TITLE
Fix/minesweeper/flag left click

### DIFF
--- a/samples/react-minesweeper/src/webparts/minesweeper/components/Grid/Minesweeper.tsx
+++ b/samples/react-minesweeper/src/webparts/minesweeper/components/Grid/Minesweeper.tsx
@@ -246,7 +246,7 @@ export default class Minesweeper extends React.Component<IMinesweeperProps, IMin
         return;
     }
 
-    if(tile.fieldType === FieldType.Number || tile.fieldType === FieldType.Empty){
+    if(tile.fieldType === FieldType.Number || tile.fieldType === FieldType.Empty || tile.fieldType === FieldType.Flag){
       return;
     }
 
@@ -254,10 +254,6 @@ export default class Minesweeper extends React.Component<IMinesweeperProps, IMin
     if(tile.hasMine){
       this.gameOver(grid, tile);
       return;
-    }
-
-    if(tile.fieldType === FieldType.Flag){
-      nrMinesLeft++;
     }
 
     let closeMines = this.getSurroundingMines(grid, coord);


### PR DESCRIPTION
|        Q        |                    A                    |
| --------------- | --------------------------------------- |
| Bug fix?        | yes                               |
| New feature?    | no                               |
| New sample?     | no                               |

## What's in this Pull Request?

FIX: user shouldn't be able to left-click on a flag.