### PR TITLE
Reset when tile.HasMine triggered infinite loop

### DIFF
--- a/samples/react-minesweeper/src/webparts/minesweeper/components/Grid/Minesweeper.tsx
+++ b/samples/react-minesweeper/src/webparts/minesweeper/components/Grid/Minesweeper.tsx
@@ -234,6 +234,7 @@ export default class Minesweeper extends React.Component<IMinesweeperProps, IMin
       case GameStatus.Idle: // first click starting the game
         while(tile.hasMine){
           grid = this.initGrid(this.state.settings);
+          tile = grid[coord.row][coord.col];
         }
 
         this.setState({


### PR DESCRIPTION
|        Q        |                    A                    |
| --------------- | --------------------------------------- |
| Bug fix?        | yes                               |
| New feature?    | no                               |
| New sample?     | no                               |

## What's in this Pull Request?

FIX: In the unlikely case that the user clicked on a mine right after resetting, the browser hanged. Now I know why :)