### PR TITLE
Enhancement: Enables user to click on header of an expanded accordion…

### DIFF
--- a/samples/react-accordion-section/README.md
+++ b/samples/react-accordion-section/README.md
@@ -52,11 +52,11 @@ SPFx Collapsible Accordion Section|[Erik Benke](https://github.com/ejbenke) ([@e
 Version|Date|Comments
 -------|----|--------
 1.0|August 14, 2019|Initial release
-1.1|September 19, 2019|Minor updates, adding to Github
+1.1|September 19, 2019|Minor updates, adding to GitHub
 1.2|April 15, 2020|Added Polyfills for IE11 compatibility
 1.3|July 10, 2020|Adding Rich Text support for Content panels
 1.4|July 10, 2020|Upgraded to SPFx 1.10.
-
+1.5|September 1, 2020|Adds ability to click on expanded section headers to collapse accordions
 
 ## Disclaimer
 

--- a/samples/react-accordion-section/config/package-solution.json
+++ b/samples/react-accordion-section/config/package-solution.json
@@ -3,7 +3,7 @@
   "solution": {
     "name": "Accordion Section FAQ Builder",
     "id": "bf6fa974-fd40-45a3-80e9-e826abe025b9",
-    "version": "1.3.0.0",
+    "version": "1.5.0.0",
     "includeClientSideAssets": true,
     "skipFeatureDeployment": true
   },

--- a/samples/react-accordion-section/package-lock.json
+++ b/samples/react-accordion-section/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-accordion",
-  "version": "0.0.1",
+  "version": "1.5.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/samples/react-accordion-section/package.json
+++ b/samples/react-accordion-section/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-accordion",
   "main": "lib/index.js",
-  "version": "0.0.1",
+  "version": "1.5.0",
   "private": true,
   "engines": {
     "node": ">=0.10.0"

--- a/samples/react-accordion-section/src/webparts/reactAccordion/components/ReactAccordion.tsx
+++ b/samples/react-accordion-section/src/webparts/reactAccordion/components/ReactAccordion.tsx
@@ -64,7 +64,7 @@ export default class ReactAccordion extends React.Component<IReactAccordionProps
         {listSelected &&
         <div>
           <h2>{this.props.accordionTitle}</h2>
-          <Accordion> 
+          <Accordion allowZeroExpanded> 
             {this.state.items.map((item:any) => {
               return (
                 <AccordionItem>


### PR DESCRIPTION
… item to collapse it (instead of an expanded item only being collapsed when a new item is expanded)

|        Q        |                    A                    |
| --------------- | --------------------------------------- |
| Bug fix?        | no                                |
| New feature?    | yes                              |
| New sample?     | no                               |
| Related issues? | addresses item number 3 of Issue #1407  |

## What's in this Pull Request?

Enhancement to address item 3 of Issue #1407.  Sets allowZeroExpanded JSX attribute of the Accordion component to true instead react-accessible-accordion library's default of false.  Result is that a user can now collapse an open accordion item by clicking on its header instead of needing to expand another item to force the collapsing of the original.




