### PR TITLE
Fix tslint warning about missing semicolon.

### DIFF
--- a/samples/react-list-form/src/webparts/listForm/components/formFields/SPFieldTaxonomyEdit.tsx
+++ b/samples/react-list-form/src/webparts/listForm/components/formFields/SPFieldTaxonomyEdit.tsx
@@ -38,7 +38,7 @@ const SPFieldTaxonomyEdit: React.SFC<ISPFormFieldProps> = (props) => {
         initialValues={terms}
         context={context}
         onChange={(items) => props.valueChanged(getUpdatedValue(items))}
-        isTermSetSelectable={false} />
+        isTermSetSelectable={false} />;
 };
 
 function getUpdatedValue(terms) {


### PR DESCRIPTION
A tslint warning about a missing semicolon was being added when building the project. I found the warning while testing another issue.

|        Q        |                    A                    |
| --------------- | --------------------------------------- |
| Bug fix?        | no                               |
| New feature?    | no                               |
| New sample?     | no                               |
| Related issues? |  |

## What's in this Pull Request?
A tslint warning was being displayed while building the project. Adding the semicolon to remove the warning




