### PR TITLE
Fix special characters in (lookup) fields (Content Query)

### DIFF
--- a/samples/react-content-query-webpart/Online/README.md
+++ b/samples/react-content-query-webpart/Online/README.md
@@ -45,6 +45,7 @@ Version|Date|Comments
 1.0.11|May 22, 2018|Fixed a bug causing filters to loose their sort order in IE
 1.0.12|April 19, 2020|Upgraded to SPFx 1.10
 1.0.13|April 28, 2020|Added support for Dynamic Data
+1.0.14|October 30, 2020|Fixed (lookup-)fields with special characters
 
 ## Disclaimer
 

--- a/samples/react-content-query-webpart/Online/README.md
+++ b/samples/react-content-query-webpart/Online/README.md
@@ -27,6 +27,7 @@ react-content-query-web part (Online)|David Warner II ([Warner Digital](http://w
 react-content-query-web part (Online)|Hugo Bernier ([Tahoe Ninjas](http://tahoeninjas.blog), [@bernierh](https://twitter.com/bernierh))
 react-content-query-web part (Online)|Paolo Pialorsi ([PiaSys.com](https://piasys.com/), [@PaoloPia](https://twitter.com/PaoloPia?s=20))
 react-content-query-web part |Simon-Pierre Plante
+react-content-query-web part (Online)|Abderahman Moujahid
 
 ## Version history
 

--- a/samples/react-content-query-webpart/Online/config/package-solution.json
+++ b/samples/react-content-query-webpart/Online/config/package-solution.json
@@ -3,7 +3,7 @@
   "solution": {
     "name": "React Content Query",
     "id": "00406271-0276-406f-9666-512623eb6709",
-    "version": "1.0.13.0",
+    "version": "1.0.14.0",
     "isDomainIsolated": false,
     "includeClientSideAssets": true
   },

--- a/samples/react-content-query-webpart/Online/src/common/services/ContentQueryService.ts
+++ b/samples/react-content-query-webpart/Online/src/common/services/ContentQueryService.ts
@@ -578,10 +578,11 @@ export class ContentQueryService implements IContentQueryService {
 
         for(let result of results) {
             let normalizedResult: any = {};
-            let formattedCharsRegex = /_x00(20|3a)_/gi;
+            let formattedCharsRegex = /_x00(20|3a|e0|e1|e2|e7|e8|e9|ea|ed|f3|f9|fa|fc)_/gi;
 
             for(let viewField of viewFields) {
                 let formattedName = viewField.replace(formattedCharsRegex, "_x005f_x00$1_x005f_");
+                formattedName = formattedName.replace(/_x00$/,"_x005f_x00");
 
                 normalizedResult[viewField] = {
                     textValue: result.FieldValuesAsText[formattedName],


### PR DESCRIPTION
|        Q        |                    A                    |
| --------------- | --------------------------------------- |
| Bug fix?        |  yes                               |
| New feature?    | no                               |
| New sample?     | no                              |
| Related issues? | fixes #1570  |

## What's in this Pull Request?

Support fields that contain special characters

|        Supported characters (at the moment)       |      
| ---------------|
| ù        |     
| ú        |
| ç        | 
| é        | 
| è        | 
| ê        | 
| à        | 
| â        | 
| á        | 
| ó        | 
| í         | 

## Example
This example shows 2 lookup fields with special characters.

![LookupSpecial](https://user-images.githubusercontent.com/36161889/97734642-b9a8b980-1ad9-11eb-889f-9c26aa85fa91.PNG)

![SpecialChars1](https://user-images.githubusercontent.com/36161889/97734675-c4fbe500-1ad9-11eb-9b0f-d9f4e44ff5b1.png)
