### PR TITLE
Returning single instance events when no recurring

### DIFF
--- a/samples/react-graph-calendar/README.md
+++ b/samples/react-graph-calendar/README.md
@@ -32,6 +32,7 @@ It is required that the users have view access on the underlying calendar.
 Solution|Author(s)
 --------|---------
 react-graph-calendar | [Sébastien Levert](https://www.linkedin.com/in/sebastienlevert) ([@sebastienlevert](https://twitter.com/sebastienlevert))
+react-graph-calendar | Abderahman Moujahid (added support for recurring events)
 
 ## Version history
 
@@ -40,6 +41,7 @@ Version|Date|Comments
 1.0 |December 29, 2019 | Initial Release
 1.1 |January 08, 2020 | Bumped to SPFx 1.10 and added the Personal Tab support
 1.2 |October 27, 2020 | Recurring events support
+1.2.1|November 1, 2020 | Changed return behavior for single items vs recurring items
 
 ## Disclaimer
 **THIS CODE IS PROVIDED *AS IS* WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING ANY IMPLIED WARRANTIES OF FITNESS FOR A PARTICULAR PURPOSE, MERCHANTABILITY, OR NON-INFRINGEMENT.**

--- a/samples/react-graph-calendar/config/package-solution.json
+++ b/samples/react-graph-calendar/config/package-solution.json
@@ -3,7 +3,7 @@
   "solution": {
     "name": "react-graph-calendar-client-side-solution",
     "id": "42fe0a0f-c4d9-4b05-806c-3857decb3d71",
-    "version": "1.0.1.0",
+    "version": "1.2.1.0",
     "includeClientSideAssets": true,
     "skipFeatureDeployment": true,
     "isDomainIsolated": false,

--- a/samples/react-graph-calendar/package-lock.json
+++ b/samples/react-graph-calendar/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-graph-calendar",
-  "version": "0.0.1",
+  "version": "1.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/samples/react-graph-calendar/package.json
+++ b/samples/react-graph-calendar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-graph-calendar",
-  "version": "0.0.1",
+  "version": "1.2.1",
   "private": true,
   "main": "lib/index.js",
   "engines": {

--- a/samples/react-graph-calendar/src/webparts/graphCalendar/components/GraphCalendar.tsx
+++ b/samples/react-graph-calendar/src/webparts/graphCalendar/components/GraphCalendar.tsx
@@ -308,11 +308,19 @@ export default class GraphCalendar extends React.Component<IGraphCalendarProps, 
               if (this.props.showRecurrence) {
                 //Get recurring events and merge with the other (standard) events
                 this._getRecurringMaster(startDate, endDate).then((recData: Array<EventInput>) => {
-                  this._getRecurrentEvents(recData, startDate, endDate).then((recEvents: Array<EventInput>) => {
-                    this.setState({
-                      events: [...recEvents, ...events].slice(0, this.props.limit),
+
+                  if(recData.length > 0) {
+                    this._getRecurrentEvents(recData, startDate, endDate).then((recEvents: Array<EventInput>) => {
+                      this.setState({
+                        events: [...recEvents, ...events].slice(0, this.props.limit),
+                      });
                     });
-                  });
+                  } else {
+                    this.setState({
+                      events: events,
+                    });
+                  }
+                                    
                 });
               } else {
                 //Show only (standard) events


### PR DESCRIPTION
|        Q        |                    A                    |
| --------------- | --------------------------------------- |
| Bug fix?        | yes                               |
| New feature?    | no                               |
| New sample?     | no                               |
| Related issues? | Closes #1564  |

## What's in this Pull Request?

The current implementation had a bug when dealing with both regular and recurring events. We now return regular events even if there are no recurring events founds in the current period.


