### PR TITLE
Added translations Graph Calendar

### DIFF
--- a/samples/react-graph-calendar/README.md
+++ b/samples/react-graph-calendar/README.md
@@ -32,7 +32,7 @@ It is required that the users have view access on the underlying calendar.
 Solution|Author(s)
 --------|---------
 react-graph-calendar | [Sébastien Levert](https://www.linkedin.com/in/sebastienlevert) ([@sebastienlevert](https://twitter.com/sebastienlevert))
-react-graph-calendar | Abderahman Moujahid (added support for recurring events)
+react-graph-calendar | Abderahman Moujahid (added support for recurring events and languages)
 
 ## Version history
 
@@ -43,6 +43,7 @@ Version|Date|Comments
 1.2 |October 27, 2020 | Recurring events support
 1.2.1|November 1, 2020 | Changed return behavior for single items vs recurring items
 1.2.2|November 3, 2020 | Show calendar in other languages
+1.2.3|November 6, 2020 | Added property panel translations (English, French, Dutch)
 
 ## Disclaimer
 **THIS CODE IS PROVIDED *AS IS* WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING ANY IMPLIED WARRANTIES OF FITNESS FOR A PARTICULAR PURPOSE, MERCHANTABILITY, OR NON-INFRINGEMENT.**

--- a/samples/react-graph-calendar/config/package-solution.json
+++ b/samples/react-graph-calendar/config/package-solution.json
@@ -3,7 +3,7 @@
   "solution": {
     "name": "react-graph-calendar-client-side-solution",
     "id": "42fe0a0f-c4d9-4b05-806c-3857decb3d71",
-    "version": "1.2.2.0",
+    "version": "1.2.3.0",
     "includeClientSideAssets": true,
     "skipFeatureDeployment": true,
     "isDomainIsolated": false,

--- a/samples/react-graph-calendar/src/webparts/graphCalendar/GraphCalendarWebPart.ts
+++ b/samples/react-graph-calendar/src/webparts/graphCalendar/GraphCalendarWebPart.ts
@@ -76,20 +76,16 @@ export default class GraphCalendarWebPart extends BaseClientSideWebPart<IGraphCa
     return {
       pages: [
         {
-          header: {
-            description: strings.PropertyPaneDescription
-          },
           groups: [
             {
-              groupName: strings.BasicGroupName,
               groupFields: [
                 PropertyPaneSlider('limit', {
-                  label: "Events to load per active view",
+                  label: strings.EventsPerView,
                   max: 500,
                   min: 50
                 }),
                 PropertyPaneCheckbox('showRecurrence', {
-                  text: "Show recurring events",
+                  text: strings.ShowRecurringEvents,
                   checked: true
                 })
               ]

--- a/samples/react-graph-calendar/src/webparts/graphCalendar/components/GraphCalendar.tsx
+++ b/samples/react-graph-calendar/src/webparts/graphCalendar/components/GraphCalendar.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { createRef } from "office-ui-fabric-react/lib/Utilities";
 import styles from './GraphCalendar.module.scss';
+import * as strings from "GraphCalendarWebPartStrings";
 import { IGraphCalendarProps } from './IGraphCalendarProps';
 import { MSGraphClient } from "@microsoft/sp-http";
 import FullCalendar from '@fullcalendar/react';
@@ -105,20 +106,20 @@ export default class GraphCalendar extends React.Component<IGraphCalendarProps, 
             headerText={this.state.currentSelectedEvent ? this.state.currentSelectedEvent.title : ""}
             onDismiss={this._closeEventPanel.bind(this)}
             isLightDismiss={true}
-            closeButtonAriaLabel='Close'>
-            <h3>Start Time</h3>
+            closeButtonAriaLabel={strings.Close}>
+            <h3>{strings.StartTime}</h3>
             <span>{moment(this.state.currentSelectedEvent.start).format('MMMM Do YYYY [at] h:mm:ss a')}</span>
-            <h3>Start Time</h3>
+            <h3>{strings.EndTime}</h3>
             <span>{moment(this.state.currentSelectedEvent.end).format('MMMM Do YYYY [at] h:mm:ss a')}</span>
             {this.state.currentSelectedEvent.extendedProps["location"] &&
               <div>
-                <h3>Location</h3>
+                <h3>{strings.Location}</h3>
                 <span>{this.state.currentSelectedEvent.extendedProps["location"]}</span>
               </div>
             }
             {this.state.currentSelectedEvent.extendedProps["body"] &&
               <div>
-                <h3>Body</h3>
+                <h3>{strings.Body}</h3>
                 <span>{this.state.currentSelectedEvent.extendedProps["body"]}</span>
               </div>
             }
@@ -425,7 +426,7 @@ export default class GraphCalendar extends React.Component<IGraphCalendarProps, 
   }
 
    /**
-   * Mapping for SharePoint laguages with Fullcalendar languages
+   * Mapping for SharePoint languages with Fullcalendar languages
    */
   private _createLangMap(): Map<string, string> {
     var languages = new Map();

--- a/samples/react-graph-calendar/src/webparts/graphCalendar/loc/en-us.js
+++ b/samples/react-graph-calendar/src/webparts/graphCalendar/loc/en-us.js
@@ -1,7 +1,11 @@
 define([], function() {
   return {
-    "PropertyPaneDescription": "Description",
-    "BasicGroupName": "Group Name",
-    "DescriptionFieldLabel": "Description Field"
+    "EventsPerView": "Events to load per active view",
+    "ShowRecurringEvents": "Show recurring events",
+    "StartTime": "Start Time",
+    "EndTime": "End Time",
+    "Location": "Location",
+    "Body": "Body",
+    "Close": "Close"
   }
 });

--- a/samples/react-graph-calendar/src/webparts/graphCalendar/loc/fr-fr.js
+++ b/samples/react-graph-calendar/src/webparts/graphCalendar/loc/fr-fr.js
@@ -1,0 +1,11 @@
+define([], function() {
+    return {
+      "EventsPerView": "Nombre d'évenements montrés par vue actif",
+      "ShowRecurringEvents": "Afficher événements récurrents",
+      "StartTime": "Heure de début",
+      "EndTime": "Heure de fin",
+      "Location": "Location",
+      "Body": "Contenu",
+      "Close": "Fermer",
+    }
+  });

--- a/samples/react-graph-calendar/src/webparts/graphCalendar/loc/mystrings.d.ts
+++ b/samples/react-graph-calendar/src/webparts/graphCalendar/loc/mystrings.d.ts
@@ -1,7 +1,11 @@
 declare interface IGraphCalendarWebPartStrings {
-  PropertyPaneDescription: string;
-  BasicGroupName: string;
-  DescriptionFieldLabel: string;
+  EventsPerView: string;
+  ShowRecurringEvents: string;
+  StartTime: string;
+  EndTime: string;
+  Location: string;
+  Body: string;
+  Close: string;
 }
 
 declare module 'GraphCalendarWebPartStrings' {

--- a/samples/react-graph-calendar/src/webparts/graphCalendar/loc/nl-nl.js
+++ b/samples/react-graph-calendar/src/webparts/graphCalendar/loc/nl-nl.js
@@ -1,0 +1,11 @@
+define([], function() {
+    return {
+      "EventsPerView": "Aantal evenementen tonen per actieve view",
+      "ShowRecurringEvents": "Toon recurrente evenementen",
+      "StartTime": "Begintijd",
+      "EndTime": "Eindtijd",
+      "Location": "Locatie",
+      "Body": "Inhoud",
+      "Close": "Sluiten",
+    }
+  });


### PR DESCRIPTION
|        Q        |                    A                    |
| --------------- | --------------------------------------- |
| Bug fix?        | no                                |
| New feature?    | yes                               |
| New sample?     | no                              |
| Related issues? |  |

## What's in this Pull Request?

- Fix label 'End Time' (Start Time was printed twice)

![IssueCalendar](https://user-images.githubusercontent.com/36161889/98393315-67c3de80-2059-11eb-8b2f-d298964b1233.PNG)

- Added French/Dutch translations of the property panel

![calendarFR2](https://user-images.githubusercontent.com/36161889/98393428-8b872480-2059-11eb-8b24-30694fd643fe.PNG)

## Remarques

- Translations may not be perfect (translators needed 😄 )
- The start-/endtime is printed in English format. (It would be better that this is translated in the language of the user.)


