### PR TITLE
Field begins with a special character (React Content Query)

### DIFF
--- a/samples/react-content-query-webpart/Online/README.md
+++ b/samples/react-content-query-webpart/Online/README.md
@@ -47,6 +47,7 @@ Version|Date|Comments
 1.0.13|April 28, 2020|Added support for Dynamic Data
 1.0.14|October 30, 2020|Fixed (lookup-)fields with special characters
 1.0.15|November 2, 2020|Upgraded to SPFx 1.11; Added support for jsonValue
+1.0.16|November 14, 2020|Fixed a bug where the fieldname starts with a special character; Added more special characters
 
 ## Disclaimer
 

--- a/samples/react-content-query-webpart/Online/config/package-solution.json
+++ b/samples/react-content-query-webpart/Online/config/package-solution.json
@@ -3,7 +3,7 @@
   "solution": {
     "name": "React Content Query",
     "id": "00406271-0276-406f-9666-512623eb6709",
-    "version": "1.0.15.0",
+    "version": "1.0.16.0",
     "isDomainIsolated": false,
     "includeClientSideAssets": true,
       "developer": {

--- a/samples/react-content-query-webpart/Online/package-lock.json
+++ b/samples/react-content-query-webpart/Online/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-content-query-webpart",
-  "version": "1.0.12",
+  "version": "1.0.15",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/samples/react-content-query-webpart/Online/package.json
+++ b/samples/react-content-query-webpart/Online/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-content-query-webpart",
-  "version": "1.0.15",
+  "version": "1.0.16",
   "private": true,
   "main": "lib/index.js",
   "engines": {

--- a/samples/react-content-query-webpart/Online/src/common/services/ContentQueryService.ts
+++ b/samples/react-content-query-webpart/Online/src/common/services/ContentQueryService.ts
@@ -583,10 +583,14 @@ export class ContentQueryService implements IContentQueryService {
 
     for (let result of results) {
       let normalizedResult: any = {};
-      let formattedCharsRegex = /_x00(20|3a|e0|e1|e2|e7|e8|e9|ea|ed|f3|f9|fa|fc)_/gi;
-
+      let formattedCharsRegex = /_x00(20|3a|[c-f]{1}[0-9a-f]{1})_/gi;
       for (let viewField of viewFields) {
-        let formattedName = viewField.replace(formattedCharsRegex, "_x005f_x00$1_x005f_");
+        //check if the intenal fieldname begins with a special character (_x00)
+        let viewFieldOdata = viewField;
+        if (viewField.indexOf("_x00") == 0) {
+          viewFieldOdata = `OData_${viewField}`;
+        }
+        let formattedName = viewFieldOdata.replace(formattedCharsRegex, "_x005f_x00$1_x005f_");
         formattedName = formattedName.replace(/_x00$/, "_x005f_x00");
         normalizedResult[viewField] = {
           textValue: result.FieldValuesAsText[formattedName],


### PR DESCRIPTION
|        Q        |                    A                    |
| --------------- | --------------------------------------- |
| Bug fix?        | yes                               |
| New feature?    | no                               |
| New sample?     | no                              |
| Related issues? | fixes #1600  |

## What's in this Pull Request?

- Fixes issue if field begins with a special character
- Added support for more special characters

|        Character        |                    Unicode                    |     Name |
| --------------- | --------------------------------------- |------------|
|  À |  x00C0 |  Agrave
|  Á |  x00C1 |  Aacute
|  Â |  x00C2 |  Acircumflex
|  Ã |  x00C3 |  Atilde
|  Ä |  x00C4 |  Adieresis
|  Å |  x00C5 |  Aring
|  Æ |  x00C6 |  AE
|  Ç |  x00C7 |  Ccedilla
|  È |  x00C8 |  Egrave
|  É |  x00C9 |  Eacute
|  Ê |  x00CA |  Ecircumflex
|  Ë |  x00CB |  Edieresis
|  Ì |  x00CC |  Igrave
|  Í |  x00CD |  Iacute
|  Î |  x00CE |  Icircumflex
|  Ï |  x00CF |  Idieresis
|  Ð |  x00D0 |  Eth
|  Ñ |  x00D1 |  Ntilde
|  Ò |  x00D2 |  Ograve
|  Ó |  x00D3|  Oacute
|  Ô |  x00D4 |  Ocircumflex
|  Õ |  x00D5 |  Otilde
|  Ö |  x00D6 |  Odieresis
|  × |  x00D7 |  multiply
|  Ø |  x00D8 |  Oslash
|  Ù |  x00D9 |  Ugrave
|  Ú |  x00DA |  Uacute
|  Û |  x00DB |  Ucircumflex
|  Ü |  x00DC |  Udieresis
|  Ý |  x00DD |  Yacute
|  Þ |  x00DE |  Thorn
|  ß |  x00DF |  germandbls
|  à |  x00E0 |  agrave
|  á |  x00E1 |  aacute
|  â |  x00E2 |  acircumflex
|  ã |  x00E3 |  atilde
|  ä |  x00E4 |  adieresis
|  å |  x00E5 |  aring
|  æ |  x00E6 |  ae
|  ç |  x00E7 |  ccedilla
|  è |  x00E8 |  egrave
|  é |  x00E9 |  eacute
|  ê |  x00EA |  ecircumflex
|  ë |  x00EB |  edieresis
|  ì |  x00EC |  igrave
|  í |  x00ED |  iacute
|  î |  x00EE |  icircumflex
|  ï |  x00EF |  idieresis
|  ð |  x00F0 |  eth
|  ñ |  x00F1 |  ntilde
|  ò |  x00F2 |  ograve
|  ó |  x00F3 |  oacute
|  ô |  x00F4 |  ocircumflex
|  õ |  x00F5 |  otilde
|  ö |  x00F6 |  odieresis
|  ÷ |  x00F7 |  divide
|  ø |  x00F8 |  oslash
|  ù |  x00F9 |  ugrave
|  ú |  x00FA |  uacute
|  û |  x00FB |  ucircumflex
|  ü |  x00FC |  udieresis
|  ý |  x00FD |  yacute
|  þ |  x00FE |  thorn
|  ÿ |  x00FF |  ydieresis


