### PR TITLE
Updated README.md

### DIFF
--- a/tutorials/tutorial-getting-started/README.md
+++ b/tutorials/tutorial-getting-started/README.md
@@ -20,7 +20,7 @@ You can also other SharePoint Framework releated videos from [SharePoint PnP You
 ## Applies to
 
 * [SharePoint Framework Developer Preview](https://docs.microsoft.com/sharepoint/dev/spfx/sharepoint-framework-overview)
-* [Office 365 developer tenant](https://docs.microsoft.com/sharepoint/dev/spfx/set-up-your-developer-tenant)
+* [Microsoft 365 developer tenant](https://docs.microsoft.com/sharepoint/dev/spfx/set-up-your-developer-tenant)
 
 ## Solution
 


### PR DESCRIPTION
Changed 'Office 365 developer tenant' to 'Microsoft 365 developer tenant'. 

SharingIsCaring ❤

|        Q        |                    A                    |
| --------------- | --------------------------------------- |
| Bug fix?        | yes                             |
| New feature?    | no                            |
| New sample?     | no                                |
| Related issues? | no|

## What's in this Pull Request?

link text referred to 'Office 365 developer tenant' which I changed to 'Microsoft 365 developer tenant'





