### PR TITLE
Fixing #1711 - Bug with default taxonomy value

### DIFF
--- a/samples/react-list-form/README.md
+++ b/samples/react-list-form/README.md
@@ -47,7 +47,8 @@ The web part allows configuring which list to use and if a form for adding a new
 | react-list-form | Harsha Vardhini ([@harshagracy](https://twitter.com/harshagracy)) |
 | react-list-form | Ryan Schouten ([@shrpntknight](https://twitter.com/shrpntknight)) |
 | react-list-form | Abderahman Moujahid                                               |
-| react-list-form | [Kman1131](https://github.com/Kman1131)
+| react-list-form | [Kman1131](https://github.com/Kman1131)                           |
+| react-list-form | Fredrik Thorild [@fthorild](https://twitter.com/fthorild)         |
 
 ## Version history
 
@@ -62,6 +63,7 @@ The web part allows configuring which list to use and if a form for adding a new
 | 1.0.6   | October 8, 2020    | Added support for cascading lookup fields                                                                 |
 | 1.0.7   | December 11, 2020  | Fix limit of lookup fields                                                                                |
 | 1.0.8   | February 7, 2021   | Fixed dragging and dropping fields                                                                        |
+| 1.0.9   | February 19, 2021  | Fixed regular expressions for text validation                                                             |
 
 ## Disclaimer
 

--- a/samples/react-list-form/config/package-solution.json
+++ b/samples/react-list-form/config/package-solution.json
@@ -3,7 +3,7 @@
   "solution": {
     "name": "react-form-webpart-client-side-solution",
     "id": "373a20ef-dfc6-456a-95ec-171de3c94581",
-    "version": "1.0.8.0",
+    "version": "1.0.9.0",
     "title": "List form",
     "supportedLocales": [
       "en-US",

--- a/samples/react-list-form/npm-shrinkwrap.json
+++ b/samples/react-list-form/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "react-form-webpart",
-  "version": "1.0.6",
+  "version": "1.0.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/samples/react-list-form/package.json
+++ b/samples/react-list-form/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-form-webpart",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "private": true,
   "engines": {
     "node": ">=0.10.0"

--- a/samples/react-list-form/src/webparts/listForm/components/ListForm.tsx
+++ b/samples/react-list-form/src/webparts/listForm/components/ListForm.tsx
@@ -300,7 +300,7 @@ class ListForm extends React.Component<IListFormProps, IListFormState> {
         const data = this.state.fieldsSchema
           .reduce((newData, fld) => {
             if (fld.DefaultValue && fld.FieldType.indexOf("TaxonomyField") > -1) {
-              newData[fld.InternalName] = fld.DefaultValue.replace(new RegExp("([#]?[0-9]+;#)", "g"), "")
+              newData[fld.InternalName] = fld.DefaultValue.replace(new RegExp("([#][0-9]+;#|^[0-9]+;#)", "g"), "")
             } else {
               newData[fld.InternalName] = fld.DefaultValue;
             }

--- a/samples/react-list-form/src/webparts/listForm/components/ListForm.tsx
+++ b/samples/react-list-form/src/webparts/listForm/components/ListForm.tsx
@@ -298,7 +298,15 @@ class ListForm extends React.Component<IListFormProps, IListFormState> {
     try {
       if ((formType === ControlMode.New) || !id) {
         const data = this.state.fieldsSchema
-          .reduce((newData, fld) => { newData[fld.InternalName] = fld.DefaultValue; return newData; }, {});
+          .reduce((newData, fld) => {
+            if (fld.DefaultValue && fld.FieldType.indexOf("TaxonomyField") > -1) {
+              newData[fld.InternalName] = fld.DefaultValue.replace(new RegExp("([#]?[0-9]+;#)", "g"), "")
+            } else {
+              newData[fld.InternalName] = fld.DefaultValue;
+            }
+            return newData;
+          },
+            {});
         this.setState({ ...this.state, data: data, originalData: { ...data }, fieldErrors: {}, isLoadingData: false });
         return;
       }


### PR DESCRIPTION
Added regex clean-up of the taxonomy strings in readData()

|        Q        |                    A                    |
| --------------- | --------------------------------------- |
| Bug fix?        | yes                               |
| New feature?    | no                             |
| New sample?     | no                               |
| Related issues? | [#1711 ](https://github.com/pnp/sp-dev-fx-webparts/issues/1711) |

## What's in this Pull Request?

As @Thomasvanderbeeck reported, when having default value(s) on taxonomy fields the form crashed. This fixes the issue by cleaning up the strings before loading the form. I have tested the following scenarios successfully:

|        Field type        |                    Case                    |  Outcome |
| --------------- | --------------------------------------- |---------|
| TaxonomyField     | Single defualt value     | 👍
| TaxonomyField     | No default value    | 👍
| TaxonomyField     | Multi defualt value     | N/A 🦄
| TaxonomyFieldMulti     | Single defualt value     | 👍
| TaxonomyFieldMulti     | No defualt value     | 👍
| TaxonomyFieldMulti     | Multi defualt value    | 👍


