### PR TITLE
[react-directory] Fix 'Sort people by'

### DIFF
--- a/samples/react-directory/README.md
+++ b/samples/react-directory/README.md
@@ -30,10 +30,14 @@
 
 ![directory](./assets/react-directory-withPaging.png) 
 
+## Compatibility
 
+![SPFx 1.11](https://img.shields.io/badge/SPFx-1.11.0-green.svg) 
+![Node.js LTS 10.x](https://img.shields.io/badge/Node.js-LTS%2010.x-green.svg) 
+![SharePoint Online](https://img.shields.io/badge/SharePoint-Online-yellow.svg) 
+![Teams N/A: Untested with Microsoft Teams](https://img.shields.io/badge/Teams-N%2FA-lightgrey.svg "Untested with Microsoft Teams") 
+![Workbench Hosted: Does not work with local workbench](https://img.shields.io/badge/Workbench-Hosted-yellow.svg "Does not work with local workbench")
 
-## Used SharePoint Framework Version 
-![SPFx 1.11](https://img.shields.io/badge/version-1.11-green.svg)
 
 ## Applies to
 
@@ -53,6 +57,7 @@ Properties to sent as clear text | text | No | By default if the search key has 
 Results per page | number | Yes | Number of people result to be displayed per page. Max of **20** is allowed, default of **10** is set. 
 
 ## Solution
+
 The web part use PnPjs library, Office-ui-fabric-react components
 
 Solution|Author(s)

--- a/samples/react-directory/README.md
+++ b/samples/react-directory/README.md
@@ -60,6 +60,7 @@ Solution|Author(s)
 Directory Web Part|João Mendes
 Directory Web Part| Peter Paul Kirschner ([@petkir_at](https://twitter.com/petkir_at))
 Directory Web Part| Sudharsan K ([@sudharsank](https://twitter.com/sudharsank))
+Directory Web Part| Abderahman Moujahid
 
 ## Version history
 
@@ -67,8 +68,9 @@ Version|Date|Comments
 -------|----|--------
 1.0.0|July 29, 2019|Initial release
 1.0.1|July 19, 2020|Bugfix and mock-service for workbench (```LivePersonaCard``` not supported in workbench)
-2.0.0.0|Sep 18 2020|React hooks, paging, dynamic search props, result alignment using office ui fabric stack.
-3.0.0.0|Oct 17 2020|Minor fixes and add the additional web part property.
+2.0.0|Sep 18 2020|React hooks, paging, dynamic search props, result alignment using office ui fabric stack.
+3.0.0|Oct 17 2020|Minor fixes and add the additional web part property.
+3.0.1|March 4 2021|Bugfix 'Sort People by'
 
 
 ## Disclaimer

--- a/samples/react-directory/config/package-solution.json
+++ b/samples/react-directory/config/package-solution.json
@@ -10,7 +10,7 @@
     },
     "name": "Search Directory",
     "id": "5b62bc16-3a71-461d-be2f-16bfcb011e8a",
-    "version": "3.0.0.0",
+    "version": "3.0.1.0",
     "includeClientSideAssets": true,
     "skipFeatureDeployment": true,
     "isDomainIsolated": false

--- a/samples/react-directory/src/SPServices/spMockServices.ts
+++ b/samples/react-directory/src/SPServices/spMockServices.ts
@@ -5,7 +5,7 @@ interface MinimalMockUser {
     FirstName: string;
     LastName: string;
     Department: string;
-    Location: string;
+    BaseOfficeLocation: string;
     Title: string;
     PreferredName: string;
     WorkPhone: string;
@@ -68,7 +68,7 @@ export class spMockServices implements ISPServices {
                         LastName: `${lastNameL}LastName${i}`,
                         PreferredName: `${firstNameL}FirstName${i} ${lastNameL}LastName${i}`,
                         Department: i % 2 === 0 ? `${lastNameL}Department` : `${firstNameL}Department`,
-                        Location: i % 3 === 0 ? `${lastNameL}Location` : `${firstNameL}Location`,
+                        BaseOfficeLocation: i % 3 === 0 ? `${lastNameL}Location` : `${firstNameL}Location`,
                         Title: i % 2 === 0 ? `${lastNameL}JobTitle` : `${firstNameL}JobTitle`,
                         WorkPhone: '' + Math.floor(Math.random() * 1234) + 54678900
                     });

--- a/samples/react-directory/src/webparts/directory/components/Directory.tsx
+++ b/samples/react-directory/src/webparts/directory/components/Directory.tsx
@@ -141,8 +141,7 @@ export default class Directory extends React.Component<
       const users = await this._services.searchUsers(
         searchText,
         this.props.searchFirstName
-      );
-debugger;
+      );  
       if (users && users.PrimarySearchResults.length > 0) {
         for (let index = 0; index < users.PrimarySearchResults.length; index++) {
           let user: any = users.PrimarySearchResults[index];

--- a/samples/react-directory/src/webparts/directory/components/DirectoryHook.tsx
+++ b/samples/react-directory/src/webparts/directory/components/DirectoryHook.tsx
@@ -192,7 +192,7 @@ const DirectoryHook: React.FC<IDirectoryProps> = (props) => {
     _searchUsers = debounce(500, _searchUsers);
 
     const _sortPeople = async (sortField: string) => {
-        let _users = state.users;
+        let _users = [...state.users];
         _users = _users.sort((a: any, b: any) => {
             switch (sortField) {
                 // Sorte by FirstName


### PR DESCRIPTION



|        Q        |                    A                    |
| --------------- | --------------------------------------- |
| Bug fix?        | yes                            |
| New feature?    | no                               |
| New sample?     | no                         |
| Related issues? | fixes #1749 

## What's in this Pull Request?

- Fixes sort-functionality (First Name, Last Name, Department, ...)
- Changed `Location` to `BaseOfficeLocation` in the mock service (sorting of people is done based on `BaseOfficeLocation`)
- Removed debugger statement in `Directory.tsx`

![sortPeople](https://user-images.githubusercontent.com/36161889/110022177-e2f98080-7d2b-11eb-96f1-2329a1ca80fe.gif)



