### PR TITLE
Added support for synchronous and asynchronous event receivers

### DIFF
--- a/samples/react-remote-event-receiver-manager/README.md
+++ b/samples/react-remote-event-receiver-manager/README.md
@@ -34,6 +34,7 @@ react remote event receiver manager | [Dan Toft](https://github.com/Tanddant) ([
 Version|Date|Comments
 -------|----|--------
 1.0.0|May 3, 2021|Initial release
+1.1.0|June 9, 2021|Added support for synchronous and asynchronous event receivers
 
 ## Minimal Path to Awesome - please follow all the steps.
 
@@ -53,9 +54,9 @@ Version|Date|Comments
 
 **THIS CODE IS PROVIDED *AS IS* WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING ANY IMPLIED WARRANTIES OF FITNESS FOR A PARTICULAR PURPOSE, MERCHANTABILITY, OR NON-INFRINGEMENT.**
 
-## Support
+## Help
 
-We do not support samples, but we do use GitHub to track issues and constantly want to improve these samples.
+We do not support samples, but we this community is always willing to help, and we want to improve these samples. We use GitHub to track issues, which makes it easy for  community members to volunteer their time and help resolve issues.
 
 If you encounter any issues while using this sample, [create a new issue](https://github.com/pnp/sp-dev-fx-webparts/issues/new?assignees=&labels=Needs%3A+Triage+%3Amag%3A%2Ctype%3Abug-suspected&template=bug-report.yml&sample=react-remote-event-receiver-manager&authors=@Tanddant&title=react-remote-event-receiver-manager%20-%20).
 

--- a/samples/react-remote-event-receiver-manager/assets/sample.json
+++ b/samples/react-remote-event-receiver-manager/assets/sample.json
@@ -9,7 +9,7 @@
       "A very simple web part that lets you add and delete remote event receivers to lists, the need came about due to remote event receivers not functioning properly when added with app only authentication and PnP.Powershell now only using that."
     ],
     "creationDateTime": "2021-05-03",
-    "updateDateTime": "2021-05-03",
+    "updateDateTime": "2021-06-09",
     "products": [
       "SharePoint",
       "Office"

--- a/samples/react-remote-event-receiver-manager/config/package-solution.json
+++ b/samples/react-remote-event-receiver-manager/config/package-solution.json
@@ -3,7 +3,7 @@
   "solution": {
     "name": "sp-fx-remote-event-receiver-manager-client-side-solution",
     "id": "ad113c85-22f8-4414-aa78-4cb897d8a285",
-    "version": "1.0.0.0",
+    "version": "1.1.0.0",
     "includeClientSideAssets": true,
     "skipFeatureDeployment": true,
     "isDomainIsolated": false,

--- a/samples/react-remote-event-receiver-manager/package.json
+++ b/samples/react-remote-event-receiver-manager/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sp-fx-remote-event-receiver-manager",
-  "version": "0.0.1",
+  "version": "1.1.0",
   "private": true,
   "main": "lib/index.js",
   "engines": {

--- a/samples/react-remote-event-receiver-manager/src/webparts/remoteEventReceiverManager/RemoteEventReceiverManagerWebPart.ts
+++ b/samples/react-remote-event-receiver-manager/src/webparts/remoteEventReceiverManager/RemoteEventReceiverManagerWebPart.ts
@@ -28,9 +28,6 @@ export default class RemoteEventReceiverManagerWebPart extends BaseClientSideWeb
   protected onInit(): Promise<void> {
 
     return super.onInit().then(_ => {
-
-      // other init code may be present
-
       pnpSetup({
         spfxContext: this.context
       });

--- a/samples/react-remote-event-receiver-manager/src/webparts/remoteEventReceiverManager/components/RemoteEventReceiverManager.tsx
+++ b/samples/react-remote-event-receiver-manager/src/webparts/remoteEventReceiverManager/components/RemoteEventReceiverManager.tsx
@@ -14,7 +14,7 @@ const SynchronizationOptions: IDropdownOption[] = [
   { key: 2, text: "Asynchronous" }
 ];
 
-const EventTypeOptions: IDropdownOption[] = [
+const EventTypeOptionsAsync: IDropdownOption[] = [
   { key: 10001, text: "ItemAdded" },
   { key: 10002, text: "ItemUpdated" },
   { key: 10003, text: "ItemDeleted" },
@@ -25,8 +25,29 @@ const EventTypeOptions: IDropdownOption[] = [
   { key: 10008, text: "ItemAttachmentDeleted" },
   { key: 10009, text: "ItemFileMoved" },
   { key: 10010, text: "ItemFileConverted" },
-  { key: 10011, text: "ItemVersionDeleted" },
 ];
+
+const EventTypeOptionsSync: IDropdownOption[] = [
+  { key: 1, text: "ItemAdding" },
+  { key: 2, text: "ItemUpdating" },
+  { key: 3, text: "ItemDeleteing" },
+  { key: 4, text: "ItemCheckingIn" },
+  { key: 5, text: "ItemCheckingOut" },
+  { key: 6, text: "ItemUncheckingOut" },
+  { key: 7, text: "ItemAttachmentAdding" },
+  { key: 8, text: "ItemAttachmentDeleting" },
+  { key: 9, text: "ItemFileMoveing" }
+];
+
+
+const getEventTypeOptions: (SynchronizationOption: number) => IDropdownOption[] = (SynchronizationOption: number) => {
+  switch (SynchronizationOption) {
+    case 1: return EventTypeOptionsSync;
+    case 2: return EventTypeOptionsAsync;
+    default:
+      return [...EventTypeOptionsAsync, ...EventTypeOptionsSync];
+  }
+};
 
 const NewEventReciever: IEventReceiver = {
   ReceiverAssembly: "Microsoft.SharePoint, Version=16.0.0.0, Culture=neutral, PublicKeyToken=71e9bce111e9429c",
@@ -99,13 +120,13 @@ export default class RemoteEventReceiverManager extends React.Component<IRemoteE
     this.loadEventReceivers(this.state.selectedList.Id);
   }
 
-
   private async deleteEventReceiver() {
     this.setState({ isSaving: true });
     await this.provider.deleteEventReceiver(this.state.selectedEventReceiver, this.state.selectedList.Id);
     this.setState({ isSaving: false, selectedEventReceiver: null, step: Step.SelectEventReceiver });
     this.loadEventReceivers(this.state.selectedList.Id);
   }
+
 
   public render(): React.ReactElement<IRemoteEventReceiverManagerProps> {
     const { selectedEventReceiver } = this.state;
@@ -176,7 +197,7 @@ export default class RemoteEventReceiverManager extends React.Component<IRemoteE
                   <TextField disabled={selectedEventReceiver.ReceiverId != ""} label={"ReceiverName"} value={selectedEventReceiver.ReceiverName} onChange={(ev, val) => this.setState({ selectedEventReceiver: { ...selectedEventReceiver, ReceiverName: val } })} />
                   <TextField disabled={selectedEventReceiver.ReceiverId != ""} label={"SequenceNumber"} type={"number"} value={selectedEventReceiver.SequenceNumber + ""} onChange={(ev, val) => this.setState({ selectedEventReceiver: { ...selectedEventReceiver, SequenceNumber: val as any as number } })} />
                   <Dropdown disabled={selectedEventReceiver.ReceiverId != ""} label={"Synchronization"} selectedKey={selectedEventReceiver.Synchronization} onChange={(ev, val) => this.setState({ selectedEventReceiver: { ...selectedEventReceiver, Synchronization: val.key as number } })} options={SynchronizationOptions} />
-                  <Dropdown disabled={selectedEventReceiver.ReceiverId != ""} label={"EventType"} selectedKey={selectedEventReceiver.EventType} onChange={(ev, val) => this.setState({ selectedEventReceiver: { ...selectedEventReceiver, EventType: val.key as number } })} options={EventTypeOptions} />
+                  <Dropdown disabled={selectedEventReceiver.ReceiverId != ""} label={"EventType"} selectedKey={selectedEventReceiver.EventType} onChange={(ev, val) => this.setState({ selectedEventReceiver: { ...selectedEventReceiver, EventType: val.key as number } })} options={getEventTypeOptions(selectedEventReceiver.Synchronization)} />
                   <TextField disabled={selectedEventReceiver.ReceiverId != ""} label={"ReceiverUrl"} value={selectedEventReceiver.ReceiverUrl} onChange={(ev, val) => this.setState({ selectedEventReceiver: { ...selectedEventReceiver, ReceiverUrl: val } })} />
                   <DialogFooter>
                     <div style={{ display: "flex", placeContent: "flex-end" }}>


### PR DESCRIPTION
> By submitting this pull request, you agree to the [contribution guidelines](https://github.com/pnp/sp-dev-fx-webparts/blob/main/CONTRIBUTING.md)

> If you aren't familiar with how to contribute to open-source repositories using GitHub, or if you find the instructions on this page confusing, [sign up](https://forms.office.com/Pages/ResponsePage.aspx?id=KtIy2vgLW0SOgZbwvQuRaXDXyCl9DkBHq4A2OG7uLpdUREZVRDVYUUJLT1VNRDM4SjhGMlpUNzBORy4u) for one of our [Sharing is Caring](https://pnp.github.io/sharing-is-caring/#pnp-sic-events) events. It's completely free, and we'll guide you through the process.


|        Q        |                    A                    |
| --------------- | --------------------------------------- |
| Bug fix?        | no                               |
| New feature?    |yes                               |
| New sample?     | no                               |
| Related issues? | |

## What's in this Pull Request?

I've added support for synchronous and asynchronous event receivers in my sample, noticed that it was missing from the sample while preparing for the demo.


