### PR TITLE
added in missing graph permissions to read users profiles / managers

### DIFF
--- a/samples/react-tree-orgchart/README.md
+++ b/samples/react-tree-orgchart/README.md
@@ -16,9 +16,16 @@ You can configure in the web part properties:
 ![Organization Chart Web Part](./assets/Screenshot3.png)
 
 
+## Compatibility
 
-## Used SharePoint Framework Version 
-![drop](https://img.shields.io/badge/version-1.10.0-green.svg)
+![SPFx 1.10.0](https://img.shields.io/badge/SPFx-1.10.0-green.svg)
+![Node.js LTS v10 | LTS v8](https://img.shields.io/badge/Node.js-LTS%20v14%20%7C%20LTS%20v12%20%7C%20LTS%20v10%20%7C%20LTS%20v8-green.svg) 
+![Compatible with SharePoint Online](https://img.shields.io/badge/SharePoint%20Online-Compatible-green.svg)
+![Does not work with SharePoint 2019](https://img.shields.io/badge/SharePoint%20Server%202019-Incompatible-red.svg "SharePoint Server 2019 requires SPFx 1.4.1 or lower")
+![Does not work with SharePoint 2016 (Feature Pack 2)](https://img.shields.io/badge/SharePoint%20Server%202016%20(Feature%20Pack%202)-Incompatible-red.svg "SharePoint Server 2016 Feature Pack 2 requires SPFx 1.1")
+![Local Workbench Incompatible](https://img.shields.io/badge/Local%20Workbench-Incompatible-red.svg "This solution requires access to read the current user's information")
+![Hosted Workbench Compatible](https://img.shields.io/badge/Hosted%20Workbench-Compatible-green.svg)
+
 
 ## Applies to
 
@@ -58,15 +65,12 @@ Tree Organization WebPart|Peter Paul Kirschner ([@petkir_at](https://twitter.com
 
 Version|Date|Comments
 -------|----|--------
+1.1.1|October 5, 2021|Added missing Graph permissions in manifest
 1.1.0|Feb 28, 2021|Added <ul><li>Show Other Team</li><li>Live Contact Card</li><li>Filter user by userPrincipalName</li><li>Graph API</li><li>PNPJS updates</li></ul> 
 1.0.2|June 12, 2020|Added exception handler for profiles missing display name 
 1.0.1|Jan 28, 2020|Update to SPFx 1.10, minor fixes and refactoring.
 1.0.0|Feb 25, 2019|Initial release  
 
-## Disclaimer
-**THIS CODE IS PROVIDED *AS IS* WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING ANY IMPLIED WARRANTIES OF FITNESS FOR A PARTICULAR PURPOSE, MERCHANTABILITY, OR NON-INFRINGEMENT.**
-
----
 
 ## Minimal Path to Awesome
 
@@ -76,5 +80,21 @@ Version|Date|Comments
   - `gulp build`
   - `gulp bundle --ship`
   - `gulp package-solution --ship`
+
+
+## Disclaimer
+
+**THIS CODE IS PROVIDED *AS IS* WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING ANY IMPLIED WARRANTIES OF FITNESS FOR A PARTICULAR PURPOSE, MERCHANTABILITY, OR NON-INFRINGEMENT.**
+
+## Help
+
+We do not support samples, but we this community is always willing to help, and we want to improve these samples. We use GitHub to track issues, which makes it easy for  community members to volunteer their time and help resolve issues.
+
+If you encounter any issues while using this sample, [create a new issue](https://github.com/pnp/sp-dev-fx-webparts/issues/new?assignees=&labels=Needs%3A+Triage+%3Amag%3A%2Ctype%3Abug-suspected&template=bug-report.yml&sample=react-tree-orgchart&authors=@joaojmendes%20@petkir&title=react-tree-orgchart%20-%20).
+
+For questions regarding this sample, [create a new question](https://github.com/pnp/sp-dev-fx-webparts/issues/new?assignees=&labels=Needs%3A+Triage+%3Amag%3A%2Ctype%3Abug-suspected&template=question.yml&sample=react-tree-orgchart&authors=@joaojmendes%20@petkir&title=react-tree-orgchart%20-%20).
+
+Finally, if you have an idea for improvement, [make a suggestion](https://github.com/pnp/sp-dev-fx-webparts/issues/new?assignees=&labels=Needs%3A+Triage+%3Amag%3A%2Ctype%3Abug-suspected&template=suggestion.yml&sample=react-tree-orgchart&authors=@joaojmendes%20@petkir&title=react-tree-orgchart%20-%20).
+
 
 <img src="https://telemetry.sharepointpnp.com/sp-dev-fx-webparts/samples/react-tree-orgchart" />

--- a/samples/react-tree-orgchart/assets/sample.json
+++ b/samples/react-tree-orgchart/assets/sample.json
@@ -9,7 +9,7 @@
       "The Tree Organization Web Part shows the Organization Chart of the or the team, the web part reads infomation from current user to build the Organization Chart."
     ],
     "creationDateTime": "2021-02-28",
-    "updateDateTime": "2021-02-28",
+    "updateDateTime": "2021-10-05",
     "products": [
       "SharePoint",
       "Office"
@@ -22,6 +22,10 @@
       {
         "key": "SPFX-VERSION",
         "value": "1.10.0"
+      },
+      {
+        "key": "PNPCONTROLS",
+        "value": "PropertyFieldNumber, PeoplePicker"
       }
     ],
     "thumbnails": [
@@ -64,7 +68,14 @@
         "pictureUrl": "https://github.com/petkir.png",
         "name": "Peter Paul Kirschner",
         "twitter": "petkir_at"
+      },
+      {
+        "gitHubAccount": "tom-daly",
+        "company": "SoHo Dragon",
+        "pictureUrl": "https://github.com/tom-daly.png",
+        "name": "Thomas Daly"
       }
+      
     ],
     "references": [
       {

--- a/samples/react-tree-orgchart/config/package-solution.json
+++ b/samples/react-tree-orgchart/config/package-solution.json
@@ -6,7 +6,13 @@
     "version": "1.1.0.0",
     "includeClientSideAssets": true,
     "skipFeatureDeployment": true,
-    "isDomainIsolated": false
+    "isDomainIsolated": false,
+    "webApiPermissionRequests": [
+      {
+        "resource": "Microsoft Graph",
+        "scope": "User.Read.All"
+      }
+    ]
   },
   "paths": {
     "zippedPackage": "solution/react-tree-orgchart.sppkg"


### PR DESCRIPTION
|        Q        |                    A                    |
| --------------- | --------------------------------------- |
| Bug fix?        |  yes                               |
| New feature?    | no                               |
| New sample?     | no                               |
| Related issues? | none |

## What's in this Pull Request?

solution was not working because the graph permissions where not in the package-solution.json file. I've added the proper json configuration. I spoke with the original author on twitter prior to submitting. 


