### PR TITLE
[react-advanced-page-properties] Fix retrieving fields from SitePages

### DIFF
--- a/samples/react-advanced-page-properties/README.md
+++ b/samples/react-advanced-page-properties/README.md
@@ -49,6 +49,7 @@ Version|Date|Comments
 -------|----|--------
 1.0.0|March 30, 2021|Initial release
 1.0.1|September 22, 2021|Added support for multi-language sites
+1.0.2|December 24, 2021|Fix retrieving fields from SitePages
 
 ## Minimal Path to Awesome
 

--- a/samples/react-advanced-page-properties/assets/sample.json
+++ b/samples/react-advanced-page-properties/assets/sample.json
@@ -15,7 +15,7 @@
       "- Improved support for dates"
     ],
     "creationDateTime": "2021-03-30",
-    "updateDateTime": "2021-09-22",
+    "updateDateTime": "2021-12-24",
     "products": [
       "SharePoint"
     ],

--- a/samples/react-advanced-page-properties/config/package-solution.json
+++ b/samples/react-advanced-page-properties/config/package-solution.json
@@ -3,7 +3,7 @@
   "solution": {
     "name": "Advanced Page Properties",
     "id": "daae06a2-8599-445c-93c0-3bd739305f56",
-    "version": "1.0.1.0",
+    "version": "1.0.2.0",
     "includeClientSideAssets": true,
     "isDomainIsolated": false,
     "developer": {

--- a/samples/react-advanced-page-properties/src/webparts/advancedPageProperties/AdvancedPagePropertiesWebPart.ts
+++ b/samples/react-advanced-page-properties/src/webparts/advancedPageProperties/AdvancedPagePropertiesWebPart.ts
@@ -68,7 +68,7 @@ export default class AdvancedPagePropertiesWebPart extends BaseClientSideWebPart
 
   private async getPageProperties(): Promise<void> {
     Log.Write("Getting Site Page fields...");
-    const list = await sp.web.lists.ensureSiteAssetsLibrary();
+    const list = await sp.web.lists.ensureSitePagesLibrary();
     const fi = await list.fields();
 
     this.availableProperties = [];

--- a/samples/react-advanced-page-properties/src/webparts/advancedPageProperties/components/AdvancedPageProperties.tsx
+++ b/samples/react-advanced-page-properties/src/webparts/advancedPageProperties/components/AdvancedPageProperties.tsx
@@ -42,9 +42,9 @@ const AdvancedPageProperties: React.FunctionComponent<IAdvancedPagePropertiesPro
 
       // Get the value(s) for the field from the list item itself
       var allValues: any = {};
-      const siteAssetsList = await sp.web.lists.ensureSitePagesLibrary();
+      const sitePagesList = await sp.web.lists.ensureSitePagesLibrary();
       if (props.context.pageContext.listItem !== undefined && props.context.pageContext.listItem !== null) {
-        allValues = await siteAssetsList.items.getById(props.context.pageContext.listItem.id).select(...props.selectedProperties).get();
+        allValues = await sitePagesList.items.getById(props.context.pageContext.listItem.id).select(...props.selectedProperties).get();
       }
 
       for (let i = 0; i < props.selectedProperties.length; i++) {
@@ -53,7 +53,7 @@ const AdvancedPageProperties: React.FunctionComponent<IAdvancedPagePropertiesPro
         Log.Write(`Selected Property: ${prop}`);
 
         // Get field information, in case anything is needed in conjunction with value types
-        const field = await siteAssetsList.fields.getByInternalNameOrTitle(prop)();
+        const field = await sitePagesList.fields.getByInternalNameOrTitle(prop)();
 
         // Establish the values array
         var values: any[] = [];


### PR DESCRIPTION

|        Q        |                    A                    |
| --------------- | --------------------------------------- |
| Bug fix?        | yes                             |
| New feature?    | no                             |
| New sample?     | no                             |
| Related issues? | fixes #2184 ,  |

## What's in this Pull Request?
Fields where retrieved for an incorrect list (SiteAssets). 
Added a correction for using the correct list (SitePages).

