### PR TITLE
Tour Sample quick update - part order

### DIFF
--- a/samples/react-tour-pnpjs/.gitignore
+++ b/samples/react-tour-pnpjs/.gitignore
@@ -30,3 +30,7 @@ obj
 
 # Styles Generated Code
 *.scss.ts
+# .CER Certificates
+*.cer
+# .PEM Certificates
+*.pem

--- a/samples/react-tour-pnpjs/assets/sample.json
+++ b/samples/react-tour-pnpjs/assets/sample.json
@@ -9,7 +9,7 @@
       "A SPFx WebPart using PnP/PnPjs, @pnp/spfx-property-controls and ReactTourJS."
     ],
     "creationDateTime": "2019-11-23",
-    "updateDateTime": "2019-11-23",
+    "updateDateTime": "2022-04-06",
     "products": [
       "SharePoint"
     ],

--- a/samples/react-tour-pnpjs/src/webparts/tour/TourWebPart.ts
+++ b/samples/react-tour-pnpjs/src/webparts/tour/TourWebPart.ts
@@ -72,11 +72,11 @@ export default class TourWebPart extends BaseClientSideWebPart<ITourWebPartProps
           var wpName = {}
           var wp = {};
           if (control.data.webPartData != undefined) {
-            wpName = `sec[${section.order}] col[${column.order}] - ${control.data.webPartData.title}`;
+            wpName = `sec[${section.order}] col[${column.order}] wp[${control.order}] - ${control.data.webPartData.title}`;
             wp = { text: wpName, key: control.data.webPartData.instanceId };
             wpData.push(wp);
           } else {
-            wpName = `sec[${section.order}] col[${column.order}] - "Webpart"`;
+            wpName = `sec[${section.order}] col[${column.order}] wp[${control.order}] - "Webpart"`;
             wp = { text: wpName, key: control.data.id };
           }
           wpData.push(wp);


### PR DESCRIPTION
A very quick update to the Tour web part to display the order of the web part, so now it's in the full order of section->column->web part ordering.

|        Q        |                    A                    |
| --------------- | --------------------------------------- |
| Bug fix?        | yes                               |
| New feature?    | no                              |
| New sample?     | no                               |
| Related issues? |  |

## What's in this Pull Request?

Just displaying the web part order for the benefit of the property pane editing to help the user know which web part they are anchoring to.