### PR TITLE
Get rid of error (name can only contain URL-Friendly characters) by Updating package.json for for js-propertycontrols-svg

### DIFF
--- a/samples/js-propertycontrols-svg/.gitignore
+++ b/samples/js-propertycontrols-svg/.gitignore
@@ -30,3 +30,9 @@ obj
 
 # Styles Generated Code
 *.scss.ts
+# .CER Certificates
+*.cer
+# .PEM Certificates
+*.pem
+
+release/webpack-stats/js-propertycontrols-svg.stats.json

--- a/samples/js-propertycontrols-svg/assets/sample.json
+++ b/samples/js-propertycontrols-svg/assets/sample.json
@@ -9,7 +9,7 @@
       "An SPFx web part that displays a Scalable Vector Graphics (SVG) image using properties to customize how it is rendered. The web part utilizes the PnP SPFx Property Controls package (specifially the SpinButton and ColorPicker) to set these properties."
     ],
     "creationDateTime": "2017-11-12",
-    "updateDateTime": "2021-12-30",
+    "updateDateTime": "2022-04-07",
     "products": [
       "SharePoint"
     ],
@@ -20,7 +20,7 @@
       },
       {
         "key": "SPFX-VERSION",
-        "value": "1.3.4"
+        "value": "1.13.0"
       },
       {
         "key": "PNPCONTROLS",

--- a/samples/js-propertycontrols-svg/package.json
+++ b/samples/js-propertycontrols-svg/package.json
@@ -18,7 +18,6 @@
     "@pnp/spfx-property-controls": "3.3.0"
   },
   "devDependencies": {
-    "microsoft/rush-stack-compiler-3.7": "0.2.3",
     "@microsoft/rush-stack-compiler-3.9": "0.4.47",
     "@microsoft/sp-build-web": "1.13.0",
     "@microsoft/sp-module-interfaces": "1.13.0",


### PR DESCRIPTION
@thechriskent Can you please remove code line 21 (which was "microsoft/rush-stack-compiler-3.7": "0.2.3",). Error was generated "name can only contain URL-Friendly characters" when that line was in the package.json, however after it was removed the code works fine. 
![image](https://user-images.githubusercontent.com/60085977/162118820-f09062fb-89ba-4285-aec0-5f5c11cde597.png)


> By submitting this pull request, you agree to the [contribution guidelines](https://github.com/pnp/sp-dev-fx-webparts/blob/main/CONTRIBUTING.md)

> If you aren't familiar with how to contribute to open-source repositories using GitHub, or if you find the instructions on this page confusing, [sign up](https://forms.office.com/Pages/ResponsePage.aspx?id=KtIy2vgLW0SOgZbwvQuRaXDXyCl9DkBHq4A2OG7uLpdUREZVRDVYUUJLT1VNRDM4SjhGMlpUNzBORy4u) for one of our [Sharing is Caring](https://pnp.github.io/sharing-is-caring/#pnp-sic-events) events. It's completely free, and we'll guide you through the process.

> `Authored-by: nader hadjebi<nader4@gmail.com>`

|        Q        |                    A                    |
| --------------- | --------------------------------------- |
| Bug fix?        | yes                              |
| New feature?    | no                               |
| New sample?     | no                             |
| Related issues? | fixes #X|

## What's in this Pull Request?

It has the edited package.json code that runs with no error.




