### PR TITLE
Modifications

### DIFF
--- a/samples/react-follow-document/README.md
+++ b/samples/react-follow-document/README.md
@@ -79,6 +79,7 @@ Version|Date|Comments
 1.0|June 22, 2021|Initial release
 2.0|November 25, 2021|Change to use Microsoft Graph Follow
 3.0|January 13, 2022|Graph fixes
+3.1|May 17, 2022|Fixed issue when no items are returned
 
 ## Minimal Path to Awesome
 

--- a/samples/react-follow-document/assets/sample.json
+++ b/samples/react-follow-document/assets/sample.json
@@ -9,7 +9,7 @@
       "identify/follow user key documents from all Tenant and easily access them in Modern Pages and Microsoft Teams"
     ],
     "creationDateTime": "2021-06-21",
-    "updateDateTime": "2022-01-13",
+    "updateDateTime": "2022-05-17",
     "products": [
       "SharePoint"
     ],
@@ -42,6 +42,11 @@
         "gitHubAccount": "aaclage",
         "pictureUrl": "https://github.com/aaclage.png",
         "name": "André Lage"
+      },
+      {
+        "gitHubAccount": "Maya-Mostafa",
+        "pictureUrl": "https://github.com/Maya-Mostafa.png",
+        "name": "Mai Mostafa"
       }
     ],
     "references": [

--- a/samples/react-follow-document/src/webparts/followDocumentWebPart/components/FollowDocumentWebPart.module.scss
+++ b/samples/react-follow-document/src/webparts/followDocumentWebPart/components/FollowDocumentWebPart.module.scss
@@ -37,3 +37,31 @@
 .DocumentCardActionsPadding{
   padding: 4px 4px;
 }
+
+// No Items message
+.emptyStateControl{
+  position: relative;
+  width: 50%;
+  text-align: center;
+  padding-bottom: 20px;
+  margin-left: auto;
+  margin-right: auto;
+  .emptyStateImage{
+    margin-top: 56px;
+  }
+  .emptyStateTextWrapper{
+    margin-top: 32px;
+    .title{
+      color: #424242;
+      font-size: 20px;
+      font-weight: 600;
+      text-align: center;
+    }
+    .subtitle{
+      color: #424242;
+      font-size: 14px;
+      font-weight: 400;
+      text-align: center;
+    }
+  }
+}

--- a/samples/react-follow-document/src/webparts/followDocumentWebPart/components/FollowDocumentWebPart.tsx
+++ b/samples/react-follow-document/src/webparts/followDocumentWebPart/components/FollowDocumentWebPart.tsx
@@ -448,6 +448,18 @@ export default class FollowDocumentWebPart extends React.Component<IFollowDocume
             onRenderGridItem={(item, finalSize: ISize, isCompact: boolean) => this._onRenderGridItem(item, finalSize, isCompact)}
           />
         </div>
+        {/* No Items message */}
+        {!this.state.visible && !this.state.ItemsSearch &&
+          <div className={styles.emptyStateControl}>
+            <div className={styles.emptyStateImage}>
+              <img src="https://res.cdn.office.net/officehub/officestartresources/favorites_light_and_dark.svg" alt="Empty state icon" />
+            </div>
+            <div className={styles.emptyStateTextWrapper}>
+              <div className={styles.title} role="status" aria-live="polite">No favorites yet</div>
+              <div className={styles.subtitle} role="status" aria-live="polite">See something you love? Favorite it and we'll put it here.</div>
+            </div>
+          </div>
+        }
       </>
     );
   }

--- a/samples/react-follow-document/src/webparts/followDocumentWebPart/components/FollowDocumentWebPart.tsx
+++ b/samples/react-follow-document/src/webparts/followDocumentWebPart/components/FollowDocumentWebPart.tsx
@@ -65,22 +65,29 @@ export default class FollowDocumentWebPart extends React.Component<IFollowDocume
     }
     let followDocuments: FollowDocument[] = [];
     this.getFollowDocuments(followDocuments).then((Items: FollowDocument[]) => {
-      //Order by Date
-      Items = Items.sort((a, b) => {
-        return b.followedDateTime.getTime() - a.followedDateTime.getTime();
-      });
-      let uniq = {};
+
       let group: Array<IDropdownOption> = new Array<IDropdownOption>();
-      //Remove duplicated from array
-      let uniqueArray = [];
-      uniqueArray = Items.filter(obj => !uniq[obj.WebUrl] && (uniq[obj.WebUrl] = true));
       group.push({ key: '0', text: 'All Sites' });
-      uniqueArray.forEach(Item => {
-        group.push({
-          key: Item.WebUrl,
-          text: "Site: " + Item.WebName,
+
+      if(Items){ //checking if there are items before performing sort & filter to fix the error of running those functions on undefined
+        //Order by Date
+        Items = Items.sort((a, b) => {
+          return b.followedDateTime.getTime() - a.followedDateTime.getTime();
         });
-      });
+
+        let uniq = {};
+        //Remove duplicated from array
+        let uniqueArray = [];
+        uniqueArray = Items.filter(obj => !uniq[obj.WebUrl] && (uniq[obj.WebUrl] = true));
+        
+        uniqueArray.forEach(Item => {
+          group.push({
+            key: Item.WebUrl,
+            text: "Site: " + Item.WebName,
+          });
+        });
+      }
+
       this.setState({
         Items: Items,
         ItemsSearch: Items,


### PR DESCRIPTION
> By submitting this pull request, you agree to the [contribution guidelines](https://github.com/pnp/sp-dev-fx-webparts/blob/main/CONTRIBUTING.md)

> If you aren't familiar with how to contribute to open-source repositories using GitHub, or if you find the instructions on this page confusing, [sign up](https://forms.office.com/Pages/ResponsePage.aspx?id=KtIy2vgLW0SOgZbwvQuRaXDXyCl9DkBHq4A2OG7uLpdUREZVRDVYUUJLT1VNRDM4SjhGMlpUNzBORy4u) for one of our [Sharing is Caring](https://pnp.github.io/sharing-is-caring/#pnp-sic-events) events. It's completely free, and we'll guide you through the process.

> To submit a pull request with multiple authors, make sure that at least one commit is a co-authored commit by adding a `Co-authored-by:` trailer to the commit's message. E.g.: `Co-authored-by: name <name@example.com>`

|        Q        |                    A                    |
| --------------- | --------------------------------------- |
| Bug fix?        | yes                            |
| New feature?    | no                               |
| New sample?     | no                              |
| Related issues? |  |

## What's in this Pull Request?

> Please describe the changes in this PR. Sample description or details around bugs which are being fixed.

### Issue
Whenever there are no items returned from the request (when there are no items followed/favorited by the current user), the web part was displaying the spinner forever with no descriptive text of what was going on. In the console, there was an error logged due to trying to perform functions (sort & filter) on undefined (no items).

### Fixes

1. Doing a check on whether there are items returned from the request before applying sort & filter functions

2. Rendering a description user-friendly message for the user when there are no items returned. Please note I used the same Microsoft Office favorites page look and feel for styling.

![nofavorites](https://user-images.githubusercontent.com/49567037/168869566-42107575-1517-4fe5-a80d-57c3c98016b0.png)


