### PR TITLE
Update issue template `bug report`

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -152,7 +152,7 @@ body:
   attributes:
     label: Paste the results of SPFx doctor
     description: |
-        Run `m365 spfx doctor -o json` and paste the results. 
+        Run `m365 spfx doctor` and paste the results. 
         
         Follow [the steps](https://github.com/pnp/sp-dev-fx-webparts/wiki/Troubleshooting-issues-with-samples#run-spfx-doctor) listed in [troubleshooting issues with samples](https://github.com/pnp/sp-dev-fx-webparts/wiki/Troubleshooting-issues-with-samples)
 


### PR DESCRIPTION
|        Q        |                    A                    |
| --------------- | --------------------------------------- |
| Bug fix?        |  yes                             |
| New feature?    | no                             |
| New sample?     | no                              |
| Related issues? | No related issue  |

## What's in this Pull Request?

When I was creating a new issue using the `bug report` template, it mentions to post the output of your current environment configuration. This could be achieved by using one of the commands from the CLI for M365, `m365 spfx doctor -o json`. The problem here is that the output type `json` isn't valid for the command `m365 spfx doctor`. The only output type that can be used here is `text`. [m365 spfx doctor documentation](https://pnp.github.io/cli-microsoft365/cmd/spfx/spfx-doctor/)

With this PR I removed the `-o json` option from the sample. 

The wiki should also be updated to reflect the possible output types. But I don't think I can update the wiki, so that's why I am mentioning it here. 😄  [Wiki #run-spfx-doctor](https://github.com/pnp/sp-dev-fx-webparts/wiki/Troubleshooting-issues-with-samples#run-spfx-doctor)
