### PR TITLE
react-page-navigator - Capability to find collapsible section headers

### DIFF
--- a/samples/react-page-navigator/README.md
+++ b/samples/react-page-navigator/README.md
@@ -27,6 +27,7 @@ Version|Date|Comments
 1.1|October 20, 2021|SPFx Upgraded to 1.12.1 and code refactored
 1.2|May, 2022|SPFx Upgraded to 1.14.0
 1.3|June 9, 2022|Updated React package from `^16.14.0` to `16.13.1`
+1.4|June 29, 2022|Adds the capability to find collapsible section headers and insert them into the navigation
 
 ## Minimal Path to Awesome
 

--- a/samples/react-page-navigator/assets/sample.json
+++ b/samples/react-page-navigator/assets/sample.json
@@ -9,7 +9,7 @@
       "This web part fetches all the automatically added Header anchor tags in a SharePoint page and displays them in a Navigation component."
     ],
     "creationDateTime": "2019-09-05",
-    "updateDateTime": "2022-05-31",
+    "updateDateTime": "2022-06-29",
     "products": [
       "SharePoint"
     ],

--- a/samples/react-page-navigator/src/Service/SPService.ts
+++ b/samples/react-page-navigator/src/Service/SPService.ts
@@ -65,6 +65,15 @@ export class SPService {
 
       /* Traverse through all the Text web parts in the page */
       canvasContent1JSON.map((webPart) => {
+        if (webPart.zoneGroupMetadata) {
+          const headingValue = webPart.zoneGroupMetadata.displayName;
+          const anchorUrl = this.GetAnchorUrl(headingValue);
+          this.allUrls.push(anchorUrl);
+
+          /* Add link to Nav element */
+          anchorLinks.push({ name: headingValue, key: anchorUrl, url: anchorUrl, links: [], isExpanded: webPart.zoneGroupMetadata.isExpanded });
+        }
+
         if (webPart.innerHTML) {
           const HTMLString: string = webPart.innerHTML;
 
@@ -75,7 +84,11 @@ export class SPService {
 
           headers.forEach(header => {
             const headingValue = header.textContent;
-            const headingOrder = parseInt(header.tagName.substring(1));
+            let headingOrder = parseInt(header.tagName.substring(1));
+
+            if (webPart.zoneGroupMetadata) {
+              headingOrder++;
+            }
 
             const anchorUrl = this.GetAnchorUrl(headingValue);
             this.allUrls.push(anchorUrl);


### PR DESCRIPTION
|        Q        |                    A                    |
| --------------- | --------------------------------------- |
| Bug fix?        | no                              |
| New feature?    | yes                              |
| New sample?     | no                             |
| Related issues? | fixes #2772  |

## What's in this Pull Request?

Adds the capability to find collapsible section headers and insert them into the navigation. This has been done within the sample `react-page-navigator`.
