### PR TITLE
fix react-list-search caml results

### DIFF
--- a/samples/react-list-search/README.md
+++ b/samples/react-list-search/README.md
@@ -86,6 +86,7 @@ Version|Date|Comments
 1.0.0|December 20, 2020|Initial release
 1.1.0|April 25, 2021|List item modern audience support
 1.2.0|January 01, 2022|Upgraded for SPFx v1.13.1
+1.3.0|July 11, 2022|Fixes CAML issues
 
 ## Minimal Path to Awesome
 

--- a/samples/react-list-search/assets/sample.json
+++ b/samples/react-list-search/assets/sample.json
@@ -9,7 +9,7 @@
       "This list search web part allows the user to show data from lists or libraries."
     ],
     "creationDateTime": "2020-12-20",
-    "updateDateTime": "2022-01-01",
+    "updateDateTime": "2022-07-11",
     "products": [
       "SharePoint"
     ],

--- a/samples/react-list-search/package-lock.json
+++ b/samples/react-list-search/package-lock.json
@@ -3018,6 +3018,16 @@
         "msal": "1.4.13",
         "msalLegacy": "npm:msal@1.4.12",
         "tslib": "~1.10.0"
+      },
+      "dependencies": {
+        "msalLegacy": {
+          "version": "npm:msal@1.4.12",
+          "resolved": "https://registry.npmjs.org/msal/-/msal-1.4.12.tgz",
+          "integrity": "sha512-gjupwQ6nvNL6mZkl5NIXyUmZhTiEMRu5giNdgHMh8l5EPOnV2Xj6nukY1NIxFacSTkEYUSDB47Pej9GxDYf+1w==",
+          "requires": {
+            "tslib": "^1.9.3"
+          }
+        }
       }
     },
     "@microsoft/sp-listview-extensibility": {
@@ -17025,14 +17035,6 @@
       "version": "1.4.13",
       "resolved": "https://registry.npmjs.org/msal/-/msal-1.4.13.tgz",
       "integrity": "sha512-uFEa4KGlpGqNMwa7/1OQc6WQUF8iwHbaiHMVn0Cl66Ec7o30ZTtX9s9OWrf0wAxp8Mwg0JEE886z/PHpsiZUxQ==",
-      "requires": {
-        "tslib": "^1.9.3"
-      }
-    },
-    "msalLegacy": {
-      "version": "npm:msal@1.4.12",
-      "resolved": "https://registry.npmjs.org/msal/-/msal-1.4.12.tgz",
-      "integrity": "sha512-gjupwQ6nvNL6mZkl5NIXyUmZhTiEMRu5giNdgHMh8l5EPOnV2Xj6nukY1NIxFacSTkEYUSDB47Pej9GxDYf+1w==",
       "requires": {
         "tslib": "^1.9.3"
       }

--- a/samples/react-list-search/src/webparts/listSearch/services/ListService.ts
+++ b/samples/react-list-search/src/webparts/listSearch/services/ListService.ts
@@ -52,12 +52,14 @@ export default class ListService implements IListService {
       if (listQueryOptions.camlQuery) {
         let query = this.getCamlQueryWithViewFieldsAndRowLimit(listQueryOptions.camlQuery, queryConfig, rowLimit);
         items = await this.getListItemsByCamlQuery(listQueryOptions.list.Id, query, queryConfig);
+        items = items.map(m => m.FieldValuesAsText);
       }
       else {
         if (listQueryOptions.viewName) {
           let viewInfo: any = await this.web.lists.getById(listQueryOptions.list.Id).views.getByTitle(listQueryOptions.viewName).select("ViewQuery").get();
           let query = this.getCamlQueryWithViewFieldsAndRowLimit(`<View><Query>${viewInfo.ViewQuery}</Query></View>`, queryConfig, rowLimit);
           items = await this.getListItemsByCamlQuery(listQueryOptions.list.Id, query, queryConfig);
+          items = items.map(m => m.FieldValuesAsText);
         }
         else {
           items = await sp.web.lists.getById(listQueryOptions.list.Id).items


### PR DESCRIPTION

|        Q        |                    A                    |
| --------------- | --------------------------------------- |
| Bug fix?        | yes                             |
| New feature?    | no                                |
| New sample?     | no                                |
| Related issues? | #1804 |

## What's in this Pull Request?

## What's in this Pull Request?
Fixing pre-existing CAML query issue, previously mentioned in [react-list-search CAML query issue #1804](https://github.com/pnp/sp-dev-fx-webparts/issues/1804), by including missing CAML query results where its currently missing.

The present CAML query option where not fully/correctly implemented, failing to display the results injected CAML queries or List view settings if inserted by the user.  As a result no values inserted within the source data CAML properties or list view title where returned, rendering both of the other features incorrectly. 




