### PR TITLE
React-list-form Fixed Caret RichTextField issues Related: #2945

### DIFF
--- a/samples/react-list-form/README.md
+++ b/samples/react-list-form/README.md
@@ -71,6 +71,7 @@ You'll need to connect to a list before you can use this sample.
 | 1.0.8   | February 7, 2021   | Fixed dragging and dropping fields                                                                        |
 | 1.0.9   | February 19, 2021  | Fixed regular expressions for text validation                                                             |
 | 1.0.10  | May 6, 2021        | Fixed "attachments are not cleared after submit" issue                                                    |
+| 1.0.11  | August 31, 2022        | Fixed Caret RichTextField issues                                                    |
 
 ## Minimal Path to Awesome
 
@@ -96,9 +97,6 @@ This Web Part illustrates the following concepts on top of the SharePoint Framew
 
 [![Building a list editing web part with React](./assets/video-thumbnail.jpg)](https://www.youtube.com/watch?v=6HbtHVZ-3Js "Building a list editing web part with React")
 
-## Disclaimer
-
-**THIS CODE IS PROVIDED _AS IS_ WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING ANY IMPLIED WARRANTIES OF FITNESS FOR A PARTICULAR PURPOSE, MERCHANTABILITY, OR NON-INFRINGEMENT.**
 
 ## Help
 
@@ -113,5 +111,9 @@ If you encounter any issues while using this sample, [create a new issue](https:
 For questions regarding this sample, [create a new question](https://github.com/pnp/sp-dev-fx-webparts/issues/new?assignees=&labels=Needs%3A+Triage+%3Amag%3A%2Ctype%3Aquestion%2Csample%3A%20react-list-form&template=question.yml&sample=react-list-form&authors=@DanyWyss%20@Harshagracy%20@sharepointknight%20@Abderahman88,%20@Kman1131%20@fthorild%20@AriGunawan&title=react-list-form%20-%20).
 
 Finally, if you have an idea for improvement, [make a suggestion](https://github.com/pnp/sp-dev-fx-webparts/issues/new?assignees=&labels=Needs%3A+Triage+%3Amag%3A%2Ctype%3Aenhancement%2Csample%3A%20react-list-form&template=question.yml&sample=react-list-form&authors=@DanyWyss%20@Harshagracy%20@sharepointknight%20@Abderahman88,%20@Kman1131%20@fthorild%20@AriGunawan&title=react-list-form%20-%20).
+
+## Disclaimer
+
+**THIS CODE IS PROVIDED _AS IS_ WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING ANY IMPLIED WARRANTIES OF FITNESS FOR A PARTICULAR PURPOSE, MERCHANTABILITY, OR NON-INFRINGEMENT.**
 
 <img src="https://pnptelemetry.azurewebsites.net/sp-dev-fx-webparts/samples/react-list-form" />

--- a/samples/react-list-form/assets/sample.json
+++ b/samples/react-list-form/assets/sample.json
@@ -5,7 +5,7 @@
     "url": "https://github.com/pnp/sp-dev-fx-webparts/tree/main/samples/react-list-form",
     "title": "List Form Web Part",
     "creationDateTime": "2017-11-24",
-    "updateDateTime": "2021-02-19",
+    "updateDateTime": "2022-08-31",
     "shortDescription": "The React List Form web part is a web part for adding a list form to any page. It provides a working example of implementing generic SharePoint list forms using the SharePoint Framework (SPFx) and the React and Office UI Fabric libraries.",
     "longDescription": [
       "The React List Form web part is a web part for adding a list form to any page. It provides a working example of implementing generic SharePoint list forms using the SharePoint Framework (SPFx) and the React and Office UI Fabric libraries."

--- a/samples/react-list-form/src/webparts/listForm/components/ListForm.tsx
+++ b/samples/react-list-form/src/webparts/listForm/components/ListForm.tsx
@@ -300,7 +300,7 @@ class ListForm extends React.Component<IListFormProps, IListFormState> {
         const data = this.state.fieldsSchema
           .reduce((newData, fld) => {
             if (fld.DefaultValue && fld.FieldType.indexOf("TaxonomyField") > -1) {
-              newData[fld.InternalName] = fld.DefaultValue.replace(new RegExp("([#][0-9]+;#|^[0-9]+;#)", "g"), "")
+              newData[fld.InternalName] = fld.DefaultValue.replace(new RegExp("([#][0-9]+;#|^[0-9]+;#)", "g"), "");
             } else {
               newData[fld.InternalName] = fld.DefaultValue;
             }

--- a/samples/react-list-form/src/webparts/listForm/components/formFields/SPFieldRichTextEdit.tsx
+++ b/samples/react-list-form/src/webparts/listForm/components/formFields/SPFieldRichTextEdit.tsx
@@ -23,9 +23,6 @@ const SPFieldRichTextEdit: React.SFC<ISPFormFieldProps> = (props) => {
     tinymce.init({});
     const { Name, RichTextMode } = props.fieldSchema;
     const value = props.value ? props.value : '';
-    if (tinymce.editors[`Editor-${Name}`] !== undefined) {
-        tinymce.editors[`Editor-${Name}`].setContent(value);
-    }
 
     const editorConfig = {
         "relative_urls": false, "convert_urls": false, "remove_script_host": false,
@@ -39,8 +36,8 @@ const SPFieldRichTextEdit: React.SFC<ISPFormFieldProps> = (props) => {
     return <Editor
         id={`Editor-${Name}`}
         init={editorConfig}
-        initialValue={props.value}
-        onChange={(event) => { props.valueChanged(event.target.getContent()); }}
+        value={value}
+        onEditorChange={props.valueChanged}
     />;
 };
 


### PR DESCRIPTION
|        Q        |                    A                    |
| --------------- | --------------------------------------- |
| Bug fix?        | yes                              |
| New feature?    | no                               |
| New sample?     | no                               |
| Related issues? | fixes #2945 |

## What's in this Pull Request?

Fixes:

1. React-list-form RichTextEditor caret is always placed on the first line
2. Pressing enter two times to get to a new line
