### PR TITLE
Added thumbnail video urls to my community call demos to my samples

### DIFF
--- a/samples/react-outlook-copy2teams/assets/sample.json
+++ b/samples/react-outlook-copy2teams/assets/sample.json
@@ -33,6 +33,12 @@
         "order": 100,
         "url": "https://camo.githubusercontent.com/a539e3ae63602becc87309ee2a965e4d5a605239/68747470733a2f2f6d6d7368617265706f696e742e66696c65732e776f726470726573732e636f6d2f323032302f30312f616464696e5f6f766572616c6c2e706e67",
         "alt": "Outlook to Teams"
+      },
+      {
+        "type": "video",
+        "order": 101,
+        "url": "https://www.youtube.com/embed/h4NXi-p2fEw",
+        "alt": "Community demo of the web part"
       }
     ],
     "authors": [

--- a/samples/react-taxonomy-file-explorer/assets/sample.json
+++ b/samples/react-taxonomy-file-explorer/assets/sample.json
@@ -41,6 +41,12 @@
                 "order": 102,
                 "url": "https://github.com/pnp/sp-dev-fx-webparts/raw/main/samples/react-taxonomy-file-explorer/assets/04Move.gif",
                 "alt": "Copying a file"
+            },
+            {
+              "type": "video",
+              "order": 103,
+              "url": "https://www.youtube.com/embed/V10hJuakgis",
+              "alt": "Community demo of the web part"
             }
         ],
         "authors": [

--- a/samples/react-teams-graph-upload-as-pdf/assets/sample.json
+++ b/samples/react-teams-graph-upload-as-pdf/assets/sample.json
@@ -29,6 +29,12 @@
                 "order": 100,
                 "url": "https://github.com/pnp/sp-dev-fx-webparts/raw/main/samples/react-teams-graph-upload-as-pdf/assets/UploadAnimated.gif",
                 "alt": "Web Part Preview"
+            },
+            {
+              "type": "video",
+              "order": 101,
+              "url": "https://www.youtube.com/embed/ikujJ0UnGAY",
+              "alt": "Community demo of the web part"
             }
         ],
         "authors": [


### PR DESCRIPTION


|        Q        |                    A                    |
| --------------- | --------------------------------------- |
| Bug fix?        | no       |
| New feature?    |  yes    |
| New sample?     | no  |
| Related issues? |  |

## What's in this Pull Request?

As discussed with @VesaJuvonen and @LuiseFreese I added the youtube-embed URLs to my community demos into the corresponding thumbnail section inside sample.json

So hopefully this is supported by your adoption-page soon once again ...

Will do the same to my numerous teams-dev-samples once I find time.
Best regards
Markus
