### PR TITLE
Fix copy-views url in sample.json file.

### DIFF
--- a/samples/react-copy-views/assets/sample.json
+++ b/samples/react-copy-views/assets/sample.json
@@ -4,12 +4,12 @@
     "source": "pnp",
     "title": "Copy Views",
     "shortDescription": "The Copy Views solution enables a user to copy views from one list/library to another across site collections.",
-    "url": "https://github.com/pnp/sp-dev-fx-webparts/tree/main/samples/react-content-query-onprem",
+    "url": "https://github.com/pnp/sp-dev-fx-webparts/tree/main/samples/react-copy-views",
     "longDescription": [
       "The Copy Views solution enables a user to copy views from one list/library to another across site collections. It can be used as a webpart on a page, or as a ListView Command Set extension. The user can select multiple views to copy to multiple target lists."
     ],
     "creationDateTime": "2022-08-29",
-    "updateDateTime": "2022-08-29",
+    "updateDateTime": "2022-09-12",
     "products": [
       "SharePoint"
     ],


### PR DESCRIPTION

|        Q        |                    A                    |
| --------------- | --------------------------------------- |
| Bug fix?        |  yes                               |
| New feature?    | no                         |
| New sample?     | no                               |
| Related issues? |  |

## What's in this Pull Request?

This PR fixes the sample.json URL value of the copy-views sample, which I forgot to update and contained a URL to the wrong sample.


