### PR TITLE
(#3029) Modify the way "empty" headings are detected

### DIFF
--- a/samples/react-page-navigator/src/Service/SPService.ts
+++ b/samples/react-page-navigator/src/Service/SPService.ts
@@ -87,7 +87,7 @@ export class SPService {
       /* Traverse through all the Text web parts in the page */
       canvasContent1JSON.map((webPart) => {
         if (webPart.zoneGroupMetadata && webPart.zoneGroupMetadata.type === 1) {
-          const headingIsEmpty: boolean = webPart.zoneGroupMetadata.displayName === '';
+          const headingIsEmpty: boolean = !webPart.zoneGroupMetadata.displayName;
           const headingValue: string = headingIsEmpty ? 'Empty Heading' : webPart.zoneGroupMetadata.displayName ;
           const anchorUrl: string = this.GetAnchorUrl(headingValue);
           this.allUrls.push(anchorUrl);
@@ -104,7 +104,7 @@ export class SPService {
           const hasCollapsableHeader: boolean = webPart.zoneGroupMetadata && 
             webPart.zoneGroupMetadata.type === 1 && 
             ( anchorLinks.filter(x => x.name === webPart.zoneGroupMetadata.displayName).length === 1 || 
-            webPart.zoneGroupMetadata.displayName === '' );
+            !webPart.zoneGroupMetadata.displayName );
 
           const htmlObject: HTMLDivElement = document.createElement('div');
           htmlObject.innerHTML = HTMLString;


### PR DESCRIPTION

|        Q        |                    A                    |
| --------------- | --------------------------------------- |
| Bug fix?        | yes                               |
| New feature?    | no                               |
| New sample?     | no                               |
| Related issues? | fixes #3029  |

## What's in this Pull Request?

The existing logic to detect "empty" sections was using the logic `webPart.zoneGroupMetadata.displayName === ''`. However, for newly created sections that never had been given a name the displayName is `undefined`. Hence, I modified the check to `!webPart.zoneGroupMetadata.displayName`.




