### PR TITLE
add await to super.onInit() in sample

### DIFF
--- a/samples/react-pnp-js-sample/src/webparts/pnPjsExample/PnPjsExampleWebPart.ts
+++ b/samples/react-pnp-js-sample/src/webparts/pnPjsExample/PnPjsExampleWebPart.ts
@@ -26,7 +26,7 @@ export default class PnPjsExampleWebPart extends BaseClientSideWebPart<IPnPjsExa
   protected async onInit(): Promise<void> {
     this._environmentMessage = this._getEnvironmentMessage();
 
-    super.onInit();
+    await super.onInit();
 
     //Initialize our _sp object that we can then use in other packages without having to pass around the context.
     //  Check out pnpjsConfig.ts for an example of a project setup file.


### PR DESCRIPTION
I was getting floating promise warning when calling super.onInit() without an await; Added await and the warning went away.

```console
[00:46:34] Warning - lint - src\webparts\listAPalooza\ListAPaloozaWebPart.ts(44,5): error @typescript-eslint/no-floating-promises: Promises mu
[00:46:34] Warning - lint - src\webparts\listAPalooza\pnpjsConfig.ts(15,15): error eqeqeq: Expected '!==' and instead saw '!='.
```

> By submitting this pull request, you agree to the [contribution guidelines](https://github.com/pnp/sp-dev-fx-webparts/blob/main/CONTRIBUTING.md)

|        Q        |                    A                    |
| --------------- | --------------------------------------- |
| Bug fix?        |   yes                               |

## What's in this Pull Request?
Fix ESLint Warning from sample... add await to async function



