### PR TITLE
disable eslint if the logic needs to be != null

### DIFF
--- a/samples/react-pnp-js-sample/src/webparts/pnPjsExample/pnpjsConfig.ts
+++ b/samples/react-pnp-js-sample/src/webparts/pnPjsExample/pnpjsConfig.ts
@@ -12,7 +12,7 @@ import "@pnp/sp/batching";
 var _sp: SPFI = null;
 
 export const getSP = (context?: WebPartContext): SPFI => {
-  if (context != null) {
+  if (context != null) { // eslint-disable-line eqeqeq
     //You must add the @pnp/logging package to include the PnPLogging behavior it is no longer a peer dependency
     // The LogLevel set's at what level a message will be written to the console
     _sp = spfi().using(SPFx(context)).using(PnPLogging(LogLevel.Warning));


### PR DESCRIPTION
Got ESLint warning in SPFx 1.15.2 new web part
```console
[00:55:35] Warning - lint - src\webparts\listAPalooza\pnpjsConfig.ts(15,15): error eqeqeq: Expected '!==' and instead saw '!='.
```

|        Q        |                    A                    |
| --------------- | --------------------------------------- |
| Bug fix?        |  yes?                               |


## What's in this Pull Request?
Just adding ESLint disable on line that might need it.
Unless the logic requires !== instead.


