### PR TITLE
revert sp-build-web and sp-webpart-workbench to ori version

### DIFF
--- a/samples/angular-greeting/package.json
+++ b/samples/angular-greeting/package.json
@@ -19,7 +19,7 @@
   },
   "devDependencies": {
     "@microsoft/rush-stack-compiler-3.7": "0.2.3",
-    "@microsoft/sp-build-web": "1.15.2",
+    "@microsoft/sp-build-web": "1.12.1",
     "@microsoft/sp-module-interfaces": "1.12.1",
     "@microsoft/sp-tslint-rules": "1.12.1",
     "@microsoft/sp-webpart-workbench": "1.12.1",

--- a/samples/angularelements-html-templatefile/package.json
+++ b/samples/angularelements-html-templatefile/package.json
@@ -34,9 +34,9 @@
     "zone.js": "^0.8.26"
   },
   "devDependencies": {
-    "@microsoft/sp-build-web": "~1.15.2",
+    "@microsoft/sp-build-web": "~1.4.1",
     "@microsoft/sp-module-interfaces": "~1.4.1",
-    "@microsoft/sp-webpart-workbench": "~1.12.1",
+    "@microsoft/sp-webpart-workbench": "~1.4.1",
     "@types/chai": ">=3.4.34 <3.6.0",
     "@types/mocha": ">=2.2.33 <2.6.0",
     "ajv": "~5.2.2",

--- a/samples/handlebarsjs-webpack-loader/package.json
+++ b/samples/handlebarsjs-webpack-loader/package.json
@@ -13,9 +13,9 @@
     "handlebars": "^4.7.7"
   },
   "devDependencies": {
-    "@microsoft/sp-build-web": "~1.15.2",
+    "@microsoft/sp-build-web": "~1.4.1",
     "@microsoft/sp-module-interfaces": "~1.4.1",
-    "@microsoft/sp-webpart-workbench": "~1.12.1",
+    "@microsoft/sp-webpart-workbench": "~1.4.1",
     "@types/chai": "~4.1.2",
     "@types/es6-collections": "^0.5.31",
     "@types/mocha": "~2.2.48",

--- a/samples/js-advanced-commenting/package.json
+++ b/samples/js-advanced-commenting/package.json
@@ -25,10 +25,10 @@
     "moment": "^2.29.2"
   },
   "devDependencies": {
-    "@microsoft/sp-build-web": "1.15.2",
+    "@microsoft/sp-build-web": "1.9.1",
     "@microsoft/sp-tslint-rules": "1.9.1",
     "@microsoft/sp-module-interfaces": "1.9.1",
-    "@microsoft/sp-webpart-workbench": "1.12.1",
+    "@microsoft/sp-webpart-workbench": "1.9.1",
     "@microsoft/rush-stack-compiler-2.9": "0.7.16",
     "gulp": "~3.9.1",
     "@types/chai": "3.4.34",

--- a/samples/js-msgraph-thumbnail/package.json
+++ b/samples/js-msgraph-thumbnail/package.json
@@ -25,10 +25,10 @@
         "@types/webpack-env": "1.13.1"
     },
     "devDependencies": {
-        "@microsoft/sp-build-web": "1.15.2",
+        "@microsoft/sp-build-web": "1.10.0",
         "@microsoft/sp-tslint-rules": "1.10.0",
         "@microsoft/sp-module-interfaces": "1.10.0",
-        "@microsoft/sp-webpart-workbench": "1.12.1",
+        "@microsoft/sp-webpart-workbench": "1.10.0",
         "@microsoft/rush-stack-compiler-3.3": "0.3.5",
         "gulp": "~3.9.1",
         "@types/chai": "3.4.34",

--- a/samples/js-myflows/package.json
+++ b/samples/js-myflows/package.json
@@ -20,10 +20,10 @@
     "@types/es6-promise": "0.0.33"
   },
   "devDependencies": {
-    "@microsoft/sp-build-web": "1.15.2",
+    "@microsoft/sp-build-web": "1.8.2",
     "@microsoft/sp-tslint-rules": "1.8.2",
     "@microsoft/sp-module-interfaces": "1.8.2",
-    "@microsoft/sp-webpart-workbench": "1.12.1",
+    "@microsoft/sp-webpart-workbench": "1.8.2",
     "@microsoft/rush-stack-compiler-2.9": "0.7.7",
     "gulp": "~3.9.1",
     "@types/chai": "3.4.34",

--- a/samples/js-public-unjoined-teams/package.json
+++ b/samples/js-public-unjoined-teams/package.json
@@ -19,10 +19,10 @@
     "@types/es6-promise": "0.0.33"
   },
   "devDependencies": {
-    "@microsoft/sp-build-web": "1.15.2",
+    "@microsoft/sp-build-web": "1.7.1-plusbeta",
     "@microsoft/sp-tslint-rules": "1.7.1-plusbeta",
     "@microsoft/sp-module-interfaces": "1.7.1-plusbeta",
-    "@microsoft/sp-webpart-workbench": "1.12.1",
+    "@microsoft/sp-webpart-workbench": "1.7.1-plusbeta",
     "gulp": "~3.9.1",
     "@types/chai": "3.4.34",
     "@types/mocha": "2.2.38",

--- a/samples/js-skype-status/package.json
+++ b/samples/js-skype-status/package.json
@@ -21,10 +21,10 @@
   },
   "devDependencies": {
     "@microsoft/rush-stack-compiler-2.7": "0.4.0",
-    "@microsoft/sp-build-web": "1.15.2",
+    "@microsoft/sp-build-web": "1.8.0",
     "@microsoft/sp-module-interfaces": "1.8.0",
     "@microsoft/sp-tslint-rules": "1.8.0",
-    "@microsoft/sp-webpart-workbench": "1.12.1",
+    "@microsoft/sp-webpart-workbench": "1.8.0",
     "@types/chai": "3.4.34",
     "@types/jquery": "^3.3.4",
     "@types/mocha": "2.2.38",

--- a/samples/js-teams-meeting-app/package.json
+++ b/samples/js-teams-meeting-app/package.json
@@ -16,7 +16,7 @@
     "@microsoft/sp-office-ui-fabric-core": "1.12.1-rc.3"
   },
   "devDependencies": {
-    "@microsoft/sp-build-web": "1.15.2",
+    "@microsoft/sp-build-web": "1.12.1-rc.3",
     "@microsoft/sp-tslint-rules": "1.12.1-rc.3",
     "@microsoft/sp-module-interfaces": "1.12.1-rc.3",
     "@microsoft/sp-webpart-workbench": "1.12.1-rc.3",

--- a/samples/js-theme-manager-2019/package.json
+++ b/samples/js-theme-manager-2019/package.json
@@ -19,9 +19,9 @@
     "@types/es6-promise": "0.0.33"
   },
   "devDependencies": {
-    "@microsoft/sp-build-web": "~1.15.2",
+    "@microsoft/sp-build-web": "~1.4.1",
     "@microsoft/sp-module-interfaces": "~1.4.1",
-    "@microsoft/sp-webpart-workbench": "~1.12.1",
+    "@microsoft/sp-webpart-workbench": "~1.4.1",
     "gulp": "~3.9.1",
     "@types/chai": "3.4.34",
     "@types/mocha": "2.2.38",

--- a/samples/js-theme-manager/package.json
+++ b/samples/js-theme-manager/package.json
@@ -22,10 +22,10 @@
   },
   "devDependencies": {
     "@microsoft/rush-stack-compiler-3.3": "0.3.5",
-    "@microsoft/sp-build-web": "1.15.2",
+    "@microsoft/sp-build-web": "1.10.0",
     "@microsoft/sp-module-interfaces": "1.10.0",
     "@microsoft/sp-tslint-rules": "1.10.0",
-    "@microsoft/sp-webpart-workbench": "1.12.1",
+    "@microsoft/sp-webpart-workbench": "1.10.0",
     "@types/chai": "3.4.34",
     "@types/mocha": "2.2.38",
     "ajv": "~5.2.2",

--- a/samples/js-workbench-customizer/package.json
+++ b/samples/js-workbench-customizer/package.json
@@ -23,10 +23,10 @@
   },
   "devDependencies": {
     "@microsoft/rush-stack-compiler-3.3": "0.3.5",
-    "@microsoft/sp-build-web": "1.15.2",
+    "@microsoft/sp-build-web": "1.10.0",
     "@microsoft/sp-module-interfaces": "1.10.0",
     "@microsoft/sp-tslint-rules": "1.10.0",
-    "@microsoft/sp-webpart-workbench": "1.12.1",
+    "@microsoft/sp-webpart-workbench": "1.10.0",
     "@types/chai": "3.4.34",
     "@types/mocha": "2.2.38",
     "ajv": "~5.2.2",

--- a/samples/knockout-sp-pnp-js/package.json
+++ b/samples/knockout-sp-pnp-js/package.json
@@ -25,10 +25,10 @@
     "knockout": "3.5.0"
   },
   "devDependencies": {
-    "@microsoft/sp-build-web": "1.15.2",
+    "@microsoft/sp-build-web": "1.7.0",
     "@microsoft/sp-tslint-rules": "1.7.0",
     "@microsoft/sp-module-interfaces": "1.7.0",
-    "@microsoft/sp-webpart-workbench": "1.12.1",
+    "@microsoft/sp-webpart-workbench": "1.7.0",
     "gulp": "~3.9.1",
     "@types/chai": "3.4.34",
     "@types/mocha": "2.2.38",

--- a/samples/react-accordion-dynamic-section/package.json
+++ b/samples/react-accordion-dynamic-section/package.json
@@ -39,10 +39,10 @@
   "devDependencies": {
     "@microsoft/rush-stack-compiler-2.9": "0.7.7",
     "@microsoft/rush-stack-compiler-3.3": "0.3.5",
-    "@microsoft/sp-build-web": "1.15.2",
+    "@microsoft/sp-build-web": "1.10.0",
     "@microsoft/sp-module-interfaces": "1.10.0",
     "@microsoft/sp-tslint-rules": "1.10.0",
-    "@microsoft/sp-webpart-workbench": "1.12.1",
+    "@microsoft/sp-webpart-workbench": "1.10.0",
     "@types/chai": "3.4.34",
     "@types/mocha": "2.2.38",
     "ajv": "~5.2.2",

--- a/samples/react-accordion-section/package.json
+++ b/samples/react-accordion-section/package.json
@@ -38,10 +38,10 @@
   "devDependencies": {
     "@microsoft/rush-stack-compiler-2.9": "0.7.7",
     "@microsoft/rush-stack-compiler-3.3": "0.3.5",
-    "@microsoft/sp-build-web": "1.15.2",
+    "@microsoft/sp-build-web": "1.10.0",
     "@microsoft/sp-module-interfaces": "1.10.0",
     "@microsoft/sp-tslint-rules": "1.10.0",
-    "@microsoft/sp-webpart-workbench": "1.12.1",
+    "@microsoft/sp-webpart-workbench": "1.10.0",
     "@types/chai": "3.4.34",
     "@types/mocha": "2.2.38",
     "ajv": "~5.2.2",

--- a/samples/react-accordion/package.json
+++ b/samples/react-accordion/package.json
@@ -32,10 +32,10 @@
   },
   "devDependencies": {
     "@microsoft/rush-stack-compiler-3.3": "0.3.5",
-    "@microsoft/sp-build-web": "1.15.2",
+    "@microsoft/sp-build-web": "1.10.0",
     "@microsoft/sp-module-interfaces": "1.10.0",
     "@microsoft/sp-tslint-rules": "1.10.0",
-    "@microsoft/sp-webpart-workbench": "1.12.1",
+    "@microsoft/sp-webpart-workbench": "1.10.0",
     "@types/chai": "3.4.34",
     "@types/mocha": "2.2.38",
     "ajv": "~5.2.2",

--- a/samples/react-adaptive-cards-image-gallery/package.json
+++ b/samples/react-adaptive-cards-image-gallery/package.json
@@ -33,10 +33,10 @@
   },
   "devDependencies": {
     "@microsoft/rush-stack-compiler-3.3": "0.3.5",
-    "@microsoft/sp-build-web": "1.15.2",
+    "@microsoft/sp-build-web": "1.10.0",
     "@microsoft/sp-module-interfaces": "1.10.0",
     "@microsoft/sp-tslint-rules": "1.10.0",
-    "@microsoft/sp-webpart-workbench": "1.12.1",
+    "@microsoft/sp-webpart-workbench": "1.10.0",
     "@types/chai": "3.4.34",
     "@types/mocha": "2.2.38",
     "ajv": "~5.2.2",

--- a/samples/react-adaptivecards-hooks/package.json
+++ b/samples/react-adaptivecards-hooks/package.json
@@ -33,10 +33,10 @@
   },
   "devDependencies": {
     "@microsoft/rush-stack-compiler-3.3": "0.3.5",
-    "@microsoft/sp-build-web": "1.15.2",
+    "@microsoft/sp-build-web": "1.11.0",
     "@microsoft/sp-module-interfaces": "1.11.0",
     "@microsoft/sp-tslint-rules": "1.11.0",
-    "@microsoft/sp-webpart-workbench": "1.12.1",
+    "@microsoft/sp-webpart-workbench": "1.11.0",
     "@types/chai": "3.4.34",
     "@types/es6-promise": "0.0.33",
     "@types/mocha": "2.2.38",

--- a/samples/react-adaptivecards/package.json
+++ b/samples/react-adaptivecards/package.json
@@ -30,7 +30,7 @@
   "devDependencies": {
     "@types/react": "16.9.36",
     "@types/react-dom": "16.9.8",
-    "@microsoft/sp-build-web": "1.15.2",
+    "@microsoft/sp-build-web": "1.12.1",
     "@microsoft/sp-tslint-rules": "1.12.1",
     "@microsoft/sp-module-interfaces": "1.12.1",
     "@microsoft/sp-webpart-workbench": "1.12.1",

--- a/samples/react-add-js-css-ref/package.json
+++ b/samples/react-add-js-css-ref/package.json
@@ -30,10 +30,10 @@
     "react-dom": "16.8.5"
   },
   "devDependencies": {
-    "@microsoft/sp-build-web": "1.15.2",
+    "@microsoft/sp-build-web": "1.9.1",
     "@microsoft/sp-tslint-rules": "1.9.1",
     "@microsoft/sp-module-interfaces": "1.9.1",
-    "@microsoft/sp-webpart-workbench": "1.12.1",
+    "@microsoft/sp-webpart-workbench": "1.9.1",
     "@microsoft/rush-stack-compiler-2.9": "0.7.16",
     "gulp": "~3.9.1",
     "@types/chai": "3.4.34",

--- a/samples/react-admin-sc-catalog-pnpjs/package.json
+++ b/samples/react-admin-sc-catalog-pnpjs/package.json
@@ -34,10 +34,10 @@
     "@types/react": "16.8.8"
   },
   "devDependencies": {
-    "@microsoft/sp-build-web": "1.15.2",
+    "@microsoft/sp-build-web": "1.9.1",
     "@microsoft/sp-tslint-rules": "1.9.1",
     "@microsoft/sp-module-interfaces": "1.9.1",
-    "@microsoft/sp-webpart-workbench": "1.12.1",
+    "@microsoft/sp-webpart-workbench": "1.9.1",
     "@microsoft/rush-stack-compiler-2.9": "0.7.16",
     "gulp": "~3.9.1",
     "@types/chai": "3.4.34",

--- a/samples/react-advanced-page-properties/package.json
+++ b/samples/react-advanced-page-properties/package.json
@@ -28,10 +28,10 @@
   "devDependencies": {
     "@types/react": "16.8.8",
     "@types/react-dom": "16.8.3",
-    "@microsoft/sp-build-web": "1.15.2",
+    "@microsoft/sp-build-web": "1.11.0",
     "@microsoft/sp-tslint-rules": "1.11.0",
     "@microsoft/sp-module-interfaces": "1.11.0",
-    "@microsoft/sp-webpart-workbench": "1.12.1",
+    "@microsoft/sp-webpart-workbench": "1.11.0",
     "@microsoft/rush-stack-compiler-3.3": "0.3.5",
     "gulp": "~3.9.1",
     "@types/chai": "3.4.34",

--- a/samples/react-aggregated-calendar/package.json
+++ b/samples/react-aggregated-calendar/package.json
@@ -26,9 +26,9 @@
     "sp-client-custom-fields": "^1.3.7"
   },
   "devDependencies": {
-    "@microsoft/sp-build-web": "~1.15.2",
+    "@microsoft/sp-build-web": "~1.4.1",
     "@microsoft/sp-module-interfaces": "~1.4.1",
-    "@microsoft/sp-webpart-workbench": "~1.12.1",
+    "@microsoft/sp-webpart-workbench": "~1.4.1",
     "@types/chai": ">=3.4.34 <3.6.0",
     "@types/mocha": ">=2.2.33 <2.6.0",
     "ajv": "~5.2.2",

--- a/samples/react-appinsights-dashboard/package.json
+++ b/samples/react-appinsights-dashboard/package.json
@@ -32,10 +32,10 @@
     "@types/react": "16.8.8"
   },
   "devDependencies": {
-    "@microsoft/sp-build-web": "1.15.2",
+    "@microsoft/sp-build-web": "1.10.0",
     "@microsoft/sp-tslint-rules": "1.10.0",
     "@microsoft/sp-module-interfaces": "1.10.0",
-    "@microsoft/sp-webpart-workbench": "1.12.1",
+    "@microsoft/sp-webpart-workbench": "1.10.0",
     "@microsoft/rush-stack-compiler-3.3": "0.3.5",
     "gulp": "~3.9.1",
     "@types/chai": "3.4.34",

--- a/samples/react-bot-framework/package.json
+++ b/samples/react-bot-framework/package.json
@@ -33,10 +33,10 @@
   },
   "devDependencies": {
     "@microsoft/rush-stack-compiler-3.3": "0.3.5",
-    "@microsoft/sp-build-web": "1.15.2",
+    "@microsoft/sp-build-web": "1.10.0",
     "@microsoft/sp-module-interfaces": "1.10.0",
     "@microsoft/sp-tslint-rules": "1.10.0",
-    "@microsoft/sp-webpart-workbench": "1.12.1",
+    "@microsoft/sp-webpart-workbench": "1.10.0",
     "@types/chai": "3.4.34",
     "@types/mocha": "2.2.38",
     "ajv": "~5.2.2",

--- a/samples/react-calendar/package.json
+++ b/samples/react-calendar/package.json
@@ -53,7 +53,7 @@
     "@microsoft/rush-stack-compiler-3.2": "0.3.17",
     "@microsoft/rush-stack-compiler-3.3": "0.3.5",
     "@microsoft/rush-stack-compiler-3.7": "0.2.3",
-    "@microsoft/sp-build-web": "1.15.2",
+    "@microsoft/sp-build-web": "1.12.1",
     "@microsoft/sp-module-interfaces": "1.12.1",
     "@microsoft/sp-tslint-rules": "1.12.1",
     "@microsoft/sp-webpart-workbench": "1.12.1",

--- a/samples/react-carousel/package.json
+++ b/samples/react-carousel/package.json
@@ -44,7 +44,7 @@
   "devDependencies": {
     "@microsoft/rush-stack-compiler-3.3": "0.3.5",
     "@microsoft/rush-stack-compiler-3.7": "0.2.3",
-    "@microsoft/sp-build-web": "1.15.2",
+    "@microsoft/sp-build-web": "1.12.1",
     "@microsoft/sp-module-interfaces": "1.12.1",
     "@microsoft/sp-tslint-rules": "1.12.1",
     "@microsoft/sp-webpart-workbench": "1.12.1",

--- a/samples/react-check-flows/package.json
+++ b/samples/react-check-flows/package.json
@@ -33,10 +33,10 @@
     "@types/react": "16.8.8"
   },
   "devDependencies": {
-    "@microsoft/sp-build-web": "1.15.2",
+    "@microsoft/sp-build-web": "1.9.1",
     "@microsoft/sp-tslint-rules": "1.9.1",
     "@microsoft/sp-module-interfaces": "1.9.1",
-    "@microsoft/sp-webpart-workbench": "1.12.1",
+    "@microsoft/sp-webpart-workbench": "1.9.1",
     "@microsoft/rush-stack-compiler-2.9": "0.7.16",
     "gulp": "~3.9.1",
     "@types/chai": "3.4.34",

--- a/samples/react-comparer/package.json
+++ b/samples/react-comparer/package.json
@@ -34,10 +34,10 @@
     "@types/react": "16.4.2"
   },
   "devDependencies": {
-    "@microsoft/sp-build-web": "1.15.2",
+    "@microsoft/sp-build-web": "1.7.1",
     "@microsoft/sp-tslint-rules": "1.7.1",
     "@microsoft/sp-module-interfaces": "1.7.1",
-    "@microsoft/sp-webpart-workbench": "1.12.1",
+    "@microsoft/sp-webpart-workbench": "1.7.1",
     "gulp": "~3.9.1",
     "@types/chai": "3.4.34",
     "@types/mocha": "2.2.38",

--- a/samples/react-components-dynamicloading/package.json
+++ b/samples/react-components-dynamicloading/package.json
@@ -25,9 +25,9 @@
     "react-dom": "15.6.2"
   },
   "devDependencies": {
-    "@microsoft/sp-build-web": "1.15.2",
+    "@microsoft/sp-build-web": "1.6.0",
     "@microsoft/sp-module-interfaces": "1.6.0",
-    "@microsoft/sp-webpart-workbench": "1.12.1",
+    "@microsoft/sp-webpart-workbench": "1.6.0",
     "tslint-microsoft-contrib": "~5.0.0",
     "gulp": "~3.9.1",
     "@types/chai": "3.4.34",

--- a/samples/react-content-query-online/package.json
+++ b/samples/react-content-query-online/package.json
@@ -65,10 +65,10 @@
   "devDependencies": {
     "@microsoft/rush-stack-compiler-2.9": "0.7.16",
     "@microsoft/rush-stack-compiler-3.3": "0.3.5",
-    "@microsoft/sp-build-web": "1.15.2",
+    "@microsoft/sp-build-web": "1.11.0",
     "@microsoft/sp-module-interfaces": "1.11.0",
     "@microsoft/sp-tslint-rules": "1.11.0",
-    "@microsoft/sp-webpart-workbench": "1.12.1",
+    "@microsoft/sp-webpart-workbench": "1.11.0",
     "@types/chai": "3.4.34",
     "@types/es6-promise": "0.0.33",
     "@types/mocha": "2.2.38",

--- a/samples/react-cross-device-data/package.json
+++ b/samples/react-cross-device-data/package.json
@@ -22,7 +22,7 @@
   "devDependencies": {
     "@types/react": "16.9.36",
     "@types/react-dom": "16.9.8",
-    "@microsoft/sp-build-web": "1.15.2",
+    "@microsoft/sp-build-web": "1.12.1",
     "@microsoft/sp-tslint-rules": "1.12.1",
     "@microsoft/sp-module-interfaces": "1.12.1",
     "@microsoft/sp-webpart-workbench": "1.12.1",

--- a/samples/react-css-in-js-typestyle/package.json
+++ b/samples/react-css-in-js-typestyle/package.json
@@ -30,10 +30,10 @@
     "@types/react": "16.8.8"
   },
   "devDependencies": {
-    "@microsoft/sp-build-web": "1.15.2",
+    "@microsoft/sp-build-web": "1.10.0",
     "@microsoft/sp-tslint-rules": "1.10.0",
     "@microsoft/sp-module-interfaces": "1.10.0",
-    "@microsoft/sp-webpart-workbench": "1.12.1",
+    "@microsoft/sp-webpart-workbench": "1.10.0",
     "@microsoft/rush-stack-compiler-3.3": "0.3.5",
     "gulp": "~3.9.1",
     "@types/chai": "3.4.34",

--- a/samples/react-custom-links/package.json
+++ b/samples/react-custom-links/package.json
@@ -31,10 +31,10 @@
   "devDependencies": {
     "@microsoft/microsoft-graph-types": "^1.12.0",
     "@microsoft/rush-stack-compiler-3.7": "^0.6.x",
-    "@microsoft/sp-build-web": "1.15.2",
+    "@microsoft/sp-build-web": "1.11.0",
     "@microsoft/sp-module-interfaces": "1.11.0",
     "@microsoft/sp-tslint-rules": "1.11.0",
-    "@microsoft/sp-webpart-workbench": "1.12.1",
+    "@microsoft/sp-webpart-workbench": "1.11.0",
     "@types/chai": "3.4.34",
     "@types/es6-promise": "0.0.33",
     "@types/mocha": "2.2.38",

--- a/samples/react-datatable-using-mui-tables/package.json
+++ b/samples/react-datatable-using-mui-tables/package.json
@@ -33,7 +33,7 @@
   "devDependencies": {
     "@types/react": "16.9.36",
     "@types/react-dom": "16.9.8",
-    "@microsoft/sp-build-web": "1.15.2",
+    "@microsoft/sp-build-web": "1.12.1",
     "@microsoft/sp-tslint-rules": "1.12.1",
     "@microsoft/sp-module-interfaces": "1.12.1",
     "@microsoft/sp-webpart-workbench": "1.12.1",

--- a/samples/react-daterangepicker/package.json
+++ b/samples/react-daterangepicker/package.json
@@ -31,10 +31,10 @@
     "@types/react": "16.8.8"
   },
   "devDependencies": {
-    "@microsoft/sp-build-web": "1.15.2",
+    "@microsoft/sp-build-web": "1.10.0",
     "@microsoft/sp-tslint-rules": "1.10.0",
     "@microsoft/sp-module-interfaces": "1.10.0",
-    "@microsoft/sp-webpart-workbench": "1.12.1",
+    "@microsoft/sp-webpart-workbench": "1.10.0",
     "@microsoft/rush-stack-compiler-3.3": "0.3.5",
     "gulp": "~3.9.1",
     "@types/chai": "3.4.34",

--- a/samples/react-dev-radar/package.json
+++ b/samples/react-dev-radar/package.json
@@ -34,10 +34,10 @@
     "@types/react": "16.8.8"
   },
   "devDependencies": {
-    "@microsoft/sp-build-web": "1.15.2",
+    "@microsoft/sp-build-web": "1.10.0",
     "@microsoft/sp-tslint-rules": "1.10.0",
     "@microsoft/sp-module-interfaces": "1.10.0",
-    "@microsoft/sp-webpart-workbench": "1.12.1",
+    "@microsoft/sp-webpart-workbench": "1.10.0",
     "@microsoft/rush-stack-compiler-3.3": "0.3.5",
     "gulp": "~3.9.1",
     "@types/chai": "3.4.34",

--- a/samples/react-display-hierarchy/package.json
+++ b/samples/react-display-hierarchy/package.json
@@ -28,10 +28,10 @@
   },
   "devDependencies": {
     "@microsoft/rush-stack-compiler-3.3": "0.3.5",
-    "@microsoft/sp-build-web": "1.15.2",
+    "@microsoft/sp-build-web": "1.11.0",
     "@microsoft/sp-module-interfaces": "1.11.0",
     "@microsoft/sp-tslint-rules": "1.11.0",
-    "@microsoft/sp-webpart-workbench": "1.12.1",
+    "@microsoft/sp-webpart-workbench": "1.11.0",
     "@types/chai": "3.4.34",
     "@types/mocha": "2.2.38",
     "ajv": "~6.12.3",

--- a/samples/react-document-links-accordion/package.json
+++ b/samples/react-document-links-accordion/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@types/react": "16.9.36",
     "@types/react-dom": "16.9.8",
-    "@microsoft/sp-build-web": "1.15.2",
+    "@microsoft/sp-build-web": "1.12.1",
     "@microsoft/sp-tslint-rules": "1.12.1",
     "@microsoft/sp-module-interfaces": "1.12.1",
     "@microsoft/sp-webpart-workbench": "1.12.1",

--- a/samples/react-documents-detailslist/package.json
+++ b/samples/react-documents-detailslist/package.json
@@ -29,10 +29,10 @@
   },
   "devDependencies": {
     "@microsoft/rush-stack-compiler-3.3": "0.3.5",
-    "@microsoft/sp-build-web": "1.15.2",
+    "@microsoft/sp-build-web": "1.10.0",
     "@microsoft/sp-module-interfaces": "1.10.0",
     "@microsoft/sp-tslint-rules": "1.10.0",
-    "@microsoft/sp-webpart-workbench": "1.12.1",
+    "@microsoft/sp-webpart-workbench": "1.10.0",
     "@types/chai": "3.4.34",
     "@types/mocha": "2.2.38",
     "ajv": "6.12.3",

--- a/samples/react-dynamics-crm-api/package.json
+++ b/samples/react-dynamics-crm-api/package.json
@@ -32,10 +32,10 @@
   },
   "devDependencies": {
     "@microsoft/rush-stack-compiler-3.7": "^0.6.1",
-    "@microsoft/sp-build-web": "1.15.2",
+    "@microsoft/sp-build-web": "1.10.0",
     "@microsoft/sp-module-interfaces": "1.10.0",
     "@microsoft/sp-tslint-rules": "1.10.0",
-    "@microsoft/sp-webpart-workbench": "1.12.1",
+    "@microsoft/sp-webpart-workbench": "1.10.0",
     "@types/chai": "3.4.34",
     "@types/mocha": "2.2.38",
     "ajv": "~6.12.3",

--- a/samples/react-edit-applicationcustomizer/package.json
+++ b/samples/react-edit-applicationcustomizer/package.json
@@ -28,10 +28,10 @@
   "devDependencies": {
     "@types/react": "16.8.8",
     "@types/react-dom": "16.8.3",
-    "@microsoft/sp-build-web": "1.15.2",
+    "@microsoft/sp-build-web": "1.11.0",
     "@microsoft/sp-tslint-rules": "1.11.0",
     "@microsoft/sp-module-interfaces": "1.11.0",
-    "@microsoft/sp-webpart-workbench": "1.12.1",
+    "@microsoft/sp-webpart-workbench": "1.11.0",
     "@microsoft/rush-stack-compiler-3.3": "0.3.5",
     "gulp": "~3.9.1",
     "@types/chai": "3.4.34",

--- a/samples/react-emoji-ratings/package.json
+++ b/samples/react-emoji-ratings/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@types/react": "16.9.36",
     "@types/react-dom": "16.9.8",
-    "@microsoft/sp-build-web": "1.15.2",
+    "@microsoft/sp-build-web": "1.12.1",
     "@microsoft/sp-tslint-rules": "1.12.1",
     "@microsoft/sp-module-interfaces": "1.12.1",
     "@microsoft/sp-webpart-workbench": "1.12.1",

--- a/samples/react-events-aggregator/package.json
+++ b/samples/react-events-aggregator/package.json
@@ -44,9 +44,9 @@
     "lodash.template": ">=4.5.0"
   },
   "devDependencies": {
-    "@microsoft/sp-build-web": "~1.15.2",
+    "@microsoft/sp-build-web": "~1.4.1",
     "@microsoft/sp-module-interfaces": "~1.4.1",
-    "@microsoft/sp-webpart-workbench": "~1.12.1",
+    "@microsoft/sp-webpart-workbench": "~1.4.1",
     "gulp": "~3.9.1",
     "@types/chai": ">=3.4.34 <3.6.0",
     "@types/mocha": ">=2.2.33 <2.6.0",

--- a/samples/react-graph-auto-batching/package.json
+++ b/samples/react-graph-auto-batching/package.json
@@ -21,7 +21,7 @@
   },
   "devDependencies": {
     "@microsoft/rush-stack-compiler-3.7": "0.2.3",
-    "@microsoft/sp-build-web": "1.15.2",
+    "@microsoft/sp-build-web": "1.13.0-beta.17",
     "@microsoft/sp-module-interfaces": "1.13.0-beta.17",
     "@microsoft/sp-tslint-rules": "1.13.0-beta.17",
     "@testing-library/react": "^12.1.2",

--- a/samples/react-hero-webpart/package.json
+++ b/samples/react-hero-webpart/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@types/react": "16.9.36",
     "@types/react-dom": "16.9.8",
-    "@microsoft/sp-build-web": "1.15.2",
+    "@microsoft/sp-build-web": "1.12.1",
     "@microsoft/sp-tslint-rules": "1.12.1",
     "@microsoft/sp-module-interfaces": "1.12.1",
     "@microsoft/sp-webpart-workbench": "1.12.1",

--- a/samples/react-project-online/package.json
+++ b/samples/react-project-online/package.json
@@ -34,10 +34,10 @@
     "@types/react": "16.8.8"
   },
   "devDependencies": {
-    "@microsoft/sp-build-web": "1.15.2",
+    "@microsoft/sp-build-web": "1.10.0",
     "@microsoft/sp-tslint-rules": "1.10.0",
     "@microsoft/sp-module-interfaces": "1.10.0",
-    "@microsoft/sp-webpart-workbench": "1.12.1",
+    "@microsoft/sp-webpart-workbench": "1.10.0",
     "@microsoft/rush-stack-compiler-3.3": "0.3.5",
     "gulp": "~3.9.1",
     "@types/chai": "3.4.34",

--- a/samples/react-script-editor-onprem/package.json
+++ b/samples/react-script-editor-onprem/package.json
@@ -23,9 +23,9 @@
         "react-dom": "15.6.2"
     },
     "devDependencies": {
-        "@microsoft/sp-build-web": "1.15.2",
+        "@microsoft/sp-build-web": "1.4.1",
         "@microsoft/sp-module-interfaces": "1.4.1",
-        "@microsoft/sp-webpart-workbench": "1.12.1",
+        "@microsoft/sp-webpart-workbench": "1.4.1",
         "@types/chai": "3.4.34",
         "@types/mocha": "2.2.38",
         "@types/prop-types": "ts2.4",

--- a/samples/react-tiles-v2/package.json
+++ b/samples/react-tiles-v2/package.json
@@ -25,10 +25,10 @@
     "typestyle": "^2.0.2"
   },
   "devDependencies": {
-    "@microsoft/sp-build-web": "1.15.2",
+    "@microsoft/sp-build-web": "1.11.0",
     "@microsoft/sp-tslint-rules": "1.11.0",
     "@microsoft/sp-module-interfaces": "1.11.0",
-    "@microsoft/sp-webpart-workbench": "1.12.1",
+    "@microsoft/sp-webpart-workbench": "1.11.0",
     "@microsoft/rush-stack-compiler-3.3": "0.3.5",
     "gulp": "~3.9.1",
     "@types/chai": "3.4.34",

--- a/samples/vue-js-org-chart/package.json
+++ b/samples/vue-js-org-chart/package.json
@@ -31,10 +31,10 @@
   },
   "devDependencies": {
     "@microsoft/rush-stack-compiler-2.7": "0.4.0",
-    "@microsoft/sp-build-web": "1.15.2",
+    "@microsoft/sp-build-web": "1.8.1",
     "@microsoft/sp-module-interfaces": "1.8.1",
     "@microsoft/sp-tslint-rules": "1.8.1",
-    "@microsoft/sp-webpart-workbench": "1.12.1",
+    "@microsoft/sp-webpart-workbench": "1.8.1",
     "@types/chai": "3.4.34",
     "@types/mocha": "2.2.38",
     "ajv": "~6.12.3",

--- a/samples/vuejs-todo-single-file-component/package.json
+++ b/samples/vuejs-todo-single-file-component/package.json
@@ -23,10 +23,10 @@
   },
   "devDependencies": {
     "@microsoft/rush-stack-compiler-3.3": "0.3.5",
-    "@microsoft/sp-build-web": "1.15.2",
+    "@microsoft/sp-build-web": "1.10.0",
     "@microsoft/sp-module-interfaces": "1.10.0",
     "@microsoft/sp-tslint-rules": "1.10.0",
-    "@microsoft/sp-webpart-workbench": "1.12.1",
+    "@microsoft/sp-webpart-workbench": "1.10.0",
     "@types/chai": "3.4.34",
     "@types/mocha": "2.2.38",
     "ajv": "~6.12.3",


### PR DESCRIPTION
|        Q        |                    A                    |
| --------------- | --------------------------------------- |
| Bug fix?        | yes                               |
| Related issues? | fixes #3077, #3073,#3039  |

## What's in this Pull Request?

set original version of
sp-build-web
sp-webpart-workbench 
in
Package.json

Projects:
angular-greeting
angularelements-html-templatefile
handlebarsjs-webpack-loader
js-advanced-commenting
js-msgraph-thumbnail
js-public-unjoined-teams
js-skype-status
js-teams-meeting-app
js-theme-manager-2019
js-theme-manager
js-workbench-customizer
js-myflows

knockout-sp-pnp-js


react-accordion
react-accordion-section
react-accordion-dynamic-section
react-adaptive-cards-image-gallery
react-adaptivecards
react-adaptivecards-hooks
react-add-js-css-ref
react-admin-sc-catalog-pnpjs
react-aggregated-calendar
react-appinsights-dashboard
react-bot-framework
react-calendar
react-carousel
react-comparer
react-components-dynamicloading
react-content-query-online
react-cross-device-data
react-css-in-js-typestyle
react-datatable-using-mui-tables
react-daterangepicker
react-dev-radar
react-display-hierarchy
react-document-links-accordion
react-documents-detailslist
react-dynamics-crm-api
react-edit-applicationcustomizer
react-emoji-ratings
react-events-aggregator
react-graph-auto-batching
react-project-online
react-script-editor-onprem

react-advanced-page-properties
react-check-flows
react-hero-webpart
react-tiles-v2

vue-js-org-chart
vuejs-todo-single-file-component