### PR TITLE
Add files via upload

### DIFF
--- a/samples/react-avatar/README.md
+++ b/samples/react-avatar/README.md
@@ -3,8 +3,7 @@
 ## Summary
 
 This is a sample web part that helps user create their avatar and save as profile picture. User can even download their avatar as PNG file. This web part can be useful in Intranet to help user create their avatar and save it as profile picture.
-
-##  
+ 
 ![directory](/samples/react-avatar/assets/reactAvatarOutcome.gif) 
 
 ## Features
@@ -76,6 +75,7 @@ Version|Date|Comments
 -------|----|--------
 1.0.0|August 1, 2020|Initial release
 1.0.1|October 20, 2020|Update to SPFx 1.11.0
+2.0.0|November 18, 2022|Added hat color, facial hair color, background color support
 
 ## Minimal Path to Awesome
 
@@ -89,10 +89,24 @@ Version|Date|Comments
 
 >  This sample can also be opened with [VS Code Remote Development](https://code.visualstudio.com/docs/remote/remote-overview). Visit https://aka.ms/spfx-devcontainer for further instructions.
 
+## Help
+
+We do not support samples, but this community is always willing to help, and we want to improve these samples. We use GitHub to track issues, which makes it easy for  community members to volunteer their time and help resolve issues.
+
+If you're having issues building the solution, please run [spfx doctor](https://pnp.github.io/cli-microsoft365/cmd/spfx/spfx-doctor/) from within the solution folder to diagnose incompatibility issues with your environment.
+
+You can try looking at [issues related to this sample](https://github.com/pnp/sp-dev-fx-webparts/issues?q=label%3A%22sample%3A%20react-avatar%22) to see if anybody else is having the same issues.
+
+You can also try looking at [discussions related to this sample](https://github.com/pnp/sp-dev-fx-webparts/discussions?discussions_q=react-avatar) and see what the community is saying.
+
+If you encounter any issues using this sample, [create a new issue](https://github.com/pnp/sp-dev-fx-webparts/issues/new?assignees=&labels=Needs%3A+Triage+%3Amag%3A%2Ctype%3Abug-suspected%2Csample%3A%20react-avatar&template=bug-report.yml&sample=react-avatar&authors=@kunj-sangani&title=react-avatar%20-%20).
+
+For questions regarding this sample, [create a new question](https://github.com/pnp/sp-dev-fx-webparts/issues/new?assignees=&labels=Needs%3A+Triage+%3Amag%3A%2Ctype%3Aquestion%2Csample%3A%20react-avatar&template=question.yml&sample=react-avatar&authors=@kunj-sangani&title=react-avatar%20-%20).
+
+Finally, if you have an idea for improvement, [make a suggestion](https://github.com/pnp/sp-dev-fx-webparts/issues/new?assignees=&labels=Needs%3A+Triage+%3Amag%3A%2Ctype%3Aenhancement%2Csample%3A%20react-avatar&template=suggestion.yml&sample=react-avatar&authors=@kunj-sangani&title=react-avatar%20-%20).
 
 ## Disclaimer
 
 **THIS CODE IS PROVIDED *AS IS* WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING ANY IMPLIED WARRANTIES OF FITNESS FOR A PARTICULAR PURPOSE, MERCHANTABILITY, OR NON-INFRINGEMENT.**
-
 
 <img src="https://pnptelemetry.azurewebsites.net/sp-dev-fx-webparts/samples/react-avatar" />

--- a/samples/react-avatar/assets/sample.json
+++ b/samples/react-avatar/assets/sample.json
@@ -9,7 +9,7 @@
       "This is a sample web part that helps user create their avatar and save as profile picture. User can even download their avatar as PNG file. This web part can be useful in Intranet to help user create their avatar and save it as profile picture."
     ],
     "creationDateTime": "2020-08-01",
-    "updateDateTime": "2020-08-01",
+    "updateDateTime": "2022-11-18",
     "products": [
       "SharePoint"
     ],

--- a/samples/react-avatar/src/webparts/avatarGenerator/components/AvatarGenerator.tsx
+++ b/samples/react-avatar/src/webparts/avatarGenerator/components/AvatarGenerator.tsx
@@ -1,3 +1,5 @@
+/* global _topvar, var2 */
+
 import * as PropTypes from 'prop-types';
 import * as React from 'react';
 import styles from './AvatarGenerator.module.scss';
@@ -17,6 +19,8 @@ import DialogActions from '@material-ui/core/DialogActions';
 import DialogContent from '@material-ui/core/DialogContent';
 import DialogContentText from '@material-ui/core/DialogContentText';
 import DialogTitle from '@material-ui/core/DialogTitle';
+
+
 
 const options: IChoiceGroupOption[] = [
   { key: AvatarStyle.Circle, text: 'Circle' },
@@ -201,16 +205,20 @@ export default class AvatarGenerator extends React.Component<IAvatarGeneratorPro
                           .map(type => {
                             return (<div className={styles.piece}
                               onClick={(ev) => {
+								
                                 var selectedData = this.optionContext["_data"];
                                 selectedData[`${option.key}`] = type;
-                                this.optionContext.setData(selectedData as any);
-                              }}
+								this.optionContext.setData(selectedData as any);
+								let _topvar = "LongHairFro";
+								}}
                             ><Piece avatarStyle="Circle"
                               pieceType="top"
                               pieceSize="100"
-                              topType={type} /></div>);
-                          })}
+							  topType={type} /></div>);
+                          })						  }
+						  
                       </TabPanel>;
+					  					  break;
                     case "accessoriesType":
                       return <TabPanel value={this.state.value} index={internalcount}>
                         {optionState.options
@@ -227,7 +235,28 @@ export default class AvatarGenerator extends React.Component<IAvatarGeneratorPro
                               accessoriesType={type} /></div>);
                           })}
                       </TabPanel>;
-                    case "hairColor":
+					  break;
+					case "hairColor":
+                      return <TabPanel value={this.state.value} index={internalcount}>
+                        {optionState.options
+                          .map(type => {
+                            return (<div className={styles.piece}
+                              onClick={(ev) => {
+                                var selectedData = this.optionContext["_data"];
+								selectedData[`${option.key}`] = type;
+                                this.optionContext.setData(selectedData as any);
+								
+                              }}
+                            > <Piece
+                                avatarStyle=""
+                                pieceType="top"
+                                pieceSize="100"
+								hairColor={type} />
+                            </div>); 
+                          })}
+                      </TabPanel>;
+					  break;
+					case "hatColor":
                       return <TabPanel value={this.state.value} index={internalcount}>
                         {optionState.options
                           .map(type => {
@@ -241,9 +270,8 @@ export default class AvatarGenerator extends React.Component<IAvatarGeneratorPro
                                 avatarStyle=""
                                 pieceType="top"
                                 pieceSize="100"
-                                topType="LongHairFro"
-                                hairColor={type} />
-                            </div>);
+                                topType="WinterHat1"
+								hatColor={type} /></div>);
                           })}
                       </TabPanel>;
                       break;
@@ -261,6 +289,24 @@ export default class AvatarGenerator extends React.Component<IAvatarGeneratorPro
                               pieceType="facialHair"
                               pieceSize="100"
                               facialHairType={type} /></div>);
+                          })}
+                      </TabPanel>;
+                      break;
+					case "facialHairColor":
+                      return <TabPanel value={this.state.value} index={internalcount}>
+                        {optionState.options
+                          .map(type => {
+                            return (<div className={styles.piece}
+                              onClick={(ev) => {
+                                var selectedData = this.optionContext["_data"];
+                                selectedData[`${option.key}`] = type;
+                                this.optionContext.setData(selectedData as any);
+                              }}
+                            ><Piece avatarStyle=""
+                              pieceType="facialHair"
+                              pieceSize="100"
+							  facialHairType="BeardMajestic"
+                              facialHairColor={type} /></div>);
                           })}
                       </TabPanel>;
                       break;
@@ -292,8 +338,9 @@ export default class AvatarGenerator extends React.Component<IAvatarGeneratorPro
                                 this.optionContext.setData(selectedData as any);
                               }}
                             ><Piece avatarStyle=""
-                              pieceType="clotheColor"
+                              pieceType="clothe"
                               pieceSize="100"
+							  clotheType="ShirtCrewNeck"
                               clotheColor={type} /></div>);
                           })}
                       </TabPanel>;
@@ -310,7 +357,8 @@ export default class AvatarGenerator extends React.Component<IAvatarGeneratorPro
                               }}
                             ><Piece avatarStyle=""
                               pieceType="graphics"
-                              pieceSize="100"
+                              pieceSize="200"
+							  style={{filter: 'invert(1)'}}
                               graphicType={type} /></div>);
                           })}
                       </TabPanel>;

--- a/samples/react-emoji-ratings/README.md
+++ b/samples/react-emoji-ratings/README.md
@@ -29,12 +29,12 @@ If you wish to directly use the package in your tenant here is [link](https://gi
 * User's rating data would be stored in SP List, below are list of columns and its relevance
 
 1. `Title`: To store user's display name (not required though)
-2. `Page Name`: To store page on which rating is given by particular user, this will have absolute url of page
+2. `Page Name`: To store page on which rating is given by particular user, this will have absolute URL of page
 3. `User`: To store user who has given feedback for particular page/news where web part is added
 4. `Comment`: To store comment provided by user while submitting reaction.
 5. Then there are 5 columns `Rating1`, `Rating2`, `Rating3`, `Rating4`, `Rating5` which will store the rating text configured by admin in web part... Only one of this 5 columns would be populated for single item in list, which is what user has selected as part of giving reaction
 
-* Below is how you can configure emoji's text and its image url
+* Below is how you can configure emoji's text and its image URL
 ![Web part in Action](./assets/EmojisConfigurations.png)
 
 I have added default emoji's images which can be used and uploaded to SharePoint library in the assets folder of this solution.
@@ -42,8 +42,8 @@ I have added default emoji's images which can be used and uploaded to SharePoint
 
 ## Compatibility
 
-![SPFx 1.11](https://img.shields.io/badge/SPFx-1.11.0-green.svg)
-![Node.js v10](https://img.shields.io/badge/Node.js-v10-green.svg)
+![SPFx 1.12.1](https://img.shields.io/badge/SPFx-1.12.1-green.svg)
+![Node.js v14 | v12 | v10](https://img.shields.io/badge/Node.js-v14%20%7C%20v12%20%7C%20v10-green.svg)
 ![Compatible with SharePoint Online](https://img.shields.io/badge/SharePoint%20Online-Compatible-green.svg)
 ![Does not work with SharePoint 2019](https://img.shields.io/badge/SharePoint%20Server%202019-Incompatible-red.svg "SharePoint Server 2019 requires SPFx 1.4.1 or lower")
 ![Does not work with SharePoint 2016 (Feature Pack 2)](https://img.shields.io/badge/SharePoint%20Server%202016%20(Feature%20Pack%202)-Incompatible-red.svg "SharePoint Server 2016 Feature Pack 2 requires SPFx 1.1")
@@ -76,6 +76,7 @@ react-emoji-ratings | [Siddharth Vaghasia](https://github.com/siddharth-vaghasia
 Version|Date|Comments
 -------|----|--------
 1.0|Sep 04, 2021|Initial release
+2.0|Nov 22, 2022|Added support for background color
 
 ## Minimal Path to Awesome
 

--- a/samples/react-emoji-ratings/assets/sample.json
+++ b/samples/react-emoji-ratings/assets/sample.json
@@ -10,7 +10,7 @@
             "We all know every organizations would be using SharePoint news features for company's internal communications from HR to IT updates and some time annoucements. News created in SharePoint are created as Pages in library. Idea behind this web part is to take employee/user's feedback as emoji reactions on particular news. This web part can also be used on wiki articles or blog posts to take similar reactions. Web part uses concept of 1 to 5 star based rating system(configurable), you can decide low to high based on your preference."
         ],
         "creationDateTime": "2021-09-24",
-        "updateDateTime": "2021-09-24",
+        "updateDateTime": "2022-11-22",
         "products": [
             "SharePoint"
         ],

--- a/samples/react-emoji-ratings/src/webparts/reactEmojiReactionRating/ReactEmojiReactionRatingWebPart.ts
+++ b/samples/react-emoji-ratings/src/webparts/reactEmojiReactionRating/ReactEmojiReactionRatingWebPart.ts
@@ -27,6 +27,7 @@ export interface IReactEmojiReactionRatingWebPartProps {
   propertyEnableComments: boolean;
   propertyEnableCount: boolean;
   propertySelectedColor: string;
+  propertySelectedEmojiColor: string;
   propertyListName: string;
   propertyListOperationMessage: string;
 }
@@ -46,6 +47,7 @@ export default class ReactEmojiReactionRatingWebPart extends BaseClientSideWebPa
         enableComments: this.properties.propertyEnableComments,
         enableCount: this.properties.propertyEnableCount,
         selectedColor: this.properties.propertySelectedColor,
+		selectedEmojiColor: this.properties.propertySelectedEmojiColor,
         listName: this.properties.propertyListName,
         displayMode: this.displayMode,
         listMessage: this.properties.propertyListOperationMessage,
@@ -166,6 +168,19 @@ export default class ReactEmojiReactionRatingWebPart extends BaseClientSideWebPa
                 PropertyFieldColorPicker('propertySelectedColor', {
                   label: 'Select background color',
                   selectedColor: this.properties.propertySelectedColor,
+                  onPropertyChange: this.onPropertyPaneFieldChanged,
+                  properties: this.properties,
+                  disabled: false,
+                  debounce: 1000,
+                  isHidden: false,
+                  alphaSliderHidden: false,
+                  style: PropertyFieldColorPickerStyle.Full,
+                  iconName: 'Precipitation',
+                  key: 'colorFieldId'
+                }),
+				PropertyFieldColorPicker('propertySelectedEmojiColor', {
+                  label: 'Selected emoji background color',
+                  selectedColor: this.properties.propertySelectedEmojiColor,
                   onPropertyChange: this.onPropertyPaneFieldChanged,
                   properties: this.properties,
                   disabled: false,

--- a/samples/react-emoji-ratings/src/webparts/reactEmojiReactionRating/ReactEmojiReactionRatingWebPart.ts
+++ b/samples/react-emoji-ratings/src/webparts/reactEmojiReactionRating/ReactEmojiReactionRatingWebPart.ts
@@ -47,7 +47,7 @@ export default class ReactEmojiReactionRatingWebPart extends BaseClientSideWebPa
         enableComments: this.properties.propertyEnableComments,
         enableCount: this.properties.propertyEnableCount,
         selectedColor: this.properties.propertySelectedColor,
-		selectedEmojiColor: this.properties.propertySelectedEmojiColor,
+	selectedEmojiColor: this.properties.propertySelectedEmojiColor,
         listName: this.properties.propertyListName,
         displayMode: this.displayMode,
         listMessage: this.properties.propertyListOperationMessage,
@@ -178,7 +178,7 @@ export default class ReactEmojiReactionRatingWebPart extends BaseClientSideWebPa
                   iconName: 'Precipitation',
                   key: 'colorFieldId'
                 }),
-				PropertyFieldColorPicker('propertySelectedEmojiColor', {
+		PropertyFieldColorPicker('propertySelectedEmojiColor', {
                   label: 'Selected emoji background color',
                   selectedColor: this.properties.propertySelectedEmojiColor,
                   onPropertyChange: this.onPropertyPaneFieldChanged,

--- a/samples/react-emoji-ratings/src/webparts/reactEmojiReactionRating/components/IReactEmojiReactionRatingProps.ts
+++ b/samples/react-emoji-ratings/src/webparts/reactEmojiReactionRating/components/IReactEmojiReactionRatingProps.ts
@@ -7,6 +7,7 @@ export interface IReactEmojiReactionRatingProps {
   enableComments: boolean;
   enableCount: boolean;
   selectedColor: string;
+  selectedEmojiColor: string;
   listName: string;
   displayMode: any;
   listMessage: string;

--- a/samples/react-emoji-ratings/src/webparts/reactEmojiReactionRating/components/ReactEmojiReactionRating.module.scss
+++ b/samples/react-emoji-ratings/src/webparts/reactEmojiReactionRating/components/ReactEmojiReactionRating.module.scss
@@ -35,7 +35,7 @@
   }
 
   .selectedEmoji {
-    background-color: firebrick !important;
+   /* background-color: #96d5de !important; */
     border-radius: 14px !important;
     cursor: pointer !important;
   }

--- a/samples/react-emoji-ratings/src/webparts/reactEmojiReactionRating/components/ReactEmojiReactionRating.tsx
+++ b/samples/react-emoji-ratings/src/webparts/reactEmojiReactionRating/components/ReactEmojiReactionRating.tsx
@@ -11,6 +11,8 @@ import Badge from '@material-ui/core/Badge/Badge';
 import { Placeholder } from "@pnp/spfx-controls-react/lib/Placeholder";
 import { Dialog, DialogFooter, DialogType } from 'office-ui-fabric-react';
 
+
+
 export default class ReactEmojiReactionRating extends React.Component<IReactEmojiReactionRatingProps, IReactEmojiReactionRatingState> {
   private _spService: spService = null;
   private _message = null;
@@ -354,8 +356,9 @@ public componentDidMount() {
     /* if (this.props.listMessage) {
       this.ShowDialogMessage("List Creation", this.props.listMessage);
     } */
-
+	
     return !(this.state.configLoaded) ? (
+
       <Placeholder iconName='Edit'
         iconText='Configure your web part'
         description='Please configure the web part.'
@@ -363,9 +366,12 @@ public componentDidMount() {
         hideButton={this.props.displayMode === DisplayMode.Read}
         onConfigure={this._onConfigure} />
     ) : (this.props.listMessage ? (
+
       <div>{this.props.listMessage}</div>
     ) :
       (
+	  
+	  
         <div className={styles.reactEmojiReactionRating} style={{
           backgroundColor: `${this.props.selectedColor
             }`
@@ -386,6 +392,7 @@ public componentDidMount() {
                         <Badge color="secondary" overlap="circular" badgeContent={this.state[tabIndex]}>
                           <img src={ratingItem.ImageUrl}
                             className={this.state.selectedRatingIndex == tabIndex ? styles.selectedEmoji : styles.stackImage}
+							style={this.state.selectedRatingIndex == tabIndex ? {backgroundColor: `${this.props.selectedEmojiColor}`} : {backgroundColor: 'rgba(0, 0, 0, 0)'}}
                             title={ratingItem.Title}
                             tabIndex={tabIndex}
                             id={tabIndex.toString()}
@@ -402,7 +409,8 @@ public componentDidMount() {
                           tabIndex={tabIndex}
                           id={tabIndex.toString()}
                           alt={ratingItem.Title}
-                          onClick={this.selectedRating} />
+                          onClick={this.selectedRating}
+						  />
                         <Label className={styles.labelClass}>{ratingItem.Title}</Label>
                       </>
                     )

--- a/templates/README-template.md
+++ b/templates/README-template.md
@@ -42,7 +42,7 @@ You can add as many screen shots as you'd like to help users understand your web
 
 This sample is optimally compatible with the following environment configuration:
 
-![SPFx 1.15.2](https://img.shields.io/badge/SPFx-1.15.2-green.svg)
+![SPFx 1.16.1](https://img.shields.io/badge/SPFx-1.16.1-green.svg)
 ![Node.js v16 | v14 | v12](https://img.shields.io/badge/Node.js-v16%20%7C%20v14%20%7C%20v12-green.svg)
 ![Compatible with SharePoint Online](https://img.shields.io/badge/SharePoint%20Online-Compatible-green.svg)
 ![Does not work with SharePoint 2019](https://img.shields.io/badge/SharePoint%20Server%202019-Incompatible-red.svg "SharePoint Server 2019 requires SPFx 1.4.1 or lower")


### PR DESCRIPTION
react-avatar:

Added 'hatColor' & 'facialHairColor' cases to switch 
Fixed 'clotheColor' pieceType value
Added "filter: invert(1)" css to 'graphicType' case so icons are visible on while background

(At the moment, the 'hatColor' prop needs adding manually to ".\node_modules\avataaars\dist\index.d.ts"
I have also opened a pull request tho get this fixed there)

react-emoji-ratings:

Added option to select the highlight color for currently selected emoji from config menu.
