### PR TITLE
Modern Script Editor - Added support for script in external template

### DIFF
--- a/samples/react-script-editor/README.md
+++ b/samples/react-script-editor/README.md
@@ -198,6 +198,7 @@ Version|Date|Comments
 1.0.19.0|August 31, 2022|Added support for section background color
 1.0.20.0|October 10, 2022|Added sample html/script with self-executing function
 1.0.21.0|March 11, 2023|Bump dependencies to allow react-script-editor to build under SPFx 1.16.1
+1.0.22.0|April 24, 2023|Added support for script in external template 
 
 
 ## Minimal Path to Awesome

--- a/samples/react-script-editor/README.md
+++ b/samples/react-script-editor/README.md
@@ -1,7 +1,7 @@
 
-# Script editor web part for modern pages built in React
+# Script editor web part for modern pages
 
-This version works only for SharePoint Online. If you want a version for Sharepoint on-premises go to [react-script-editor-onprem](../react-script-editor-onprem).
+This version works only for SharePoint Online. If you want a version for SharePoint on-premises go to [react-script-editor-onprem](../react-script-editor-onprem).
 
 **It's important you read and understand the notes on [deployment](#deploy-to-non-script-sites--modern-team-sites).**
 
@@ -130,7 +130,7 @@ By default this web part is not allowed on no-script sites, as it allows executi
 
 If you however want to allow the web part for non-script sites like Office 365 Group modern team sites you have to edit `ScriptEditorWebPart.manifest.json` with the following change:
 
-```
+```json
 "requiresCustomScript": false
 ```
 
@@ -138,7 +138,7 @@ If you however want to allow the web part for non-script sites like Office 365 G
 
 By default you have to install this web part per site collection where you want it available. If you want it enabled by default on all sites you have to edit `package-solution.json` with the following change:
 
-```
+```json
 "skipFeatureDeployment": true
 ```
 
@@ -171,6 +171,8 @@ This sample is optimally compatible with the following environment configuration
 
 * [Mikael Svenson](https://github.com/wobba) 
 * [Felix Bohnacker](https://github.com/felixbohnackerfelixbohnacker)
+* [salascz](https://github.com/salascz)
+* [Waldek Mastykarz](https://github.com/waldekmastykarz)
 
 ## Version history
 
@@ -203,7 +205,7 @@ Version|Date|Comments
 
 ## Minimal Path to Awesome
 
-### Local testing
+### Testing
 
 * Clone this repository
 * In the command line run:
@@ -237,11 +239,11 @@ You can try looking at [issues related to this sample](https://github.com/pnp/sp
 
 You can also try looking at [discussions related to this sample](https://github.com/pnp/sp-dev-fx-webparts/discussions?discussions_q=react-script-editor) and see what the community is saying.
 
-If you encounter any issues while using this sample, [create a new issue](https://github.com/pnp/sp-dev-fx-webparts/issues/new?assignees=&labels=Needs%3A+Triage+%3Amag%3A%2Ctype%3Abug-suspected%2Csample%3A%20react-script-editor&template=bug-report.yml&sample=react-script-editor&authors=@wobba&title=react-script-editor%20-%20).
+If you encounter any issues while using this sample, [create a new issue](https://github.com/pnp/sp-dev-fx-webparts/issues/new?assignees=&labels=Needs%3A+Triage+%3Amag%3A%2Ctype%3Abug-suspected%2Csample%3A%20react-script-editor&template=bug-report.yml&sample=react-script-editor&authors=@wobba%20@salascz%20@felixbohnacker&title=react-script-editor%20-%20).
 
-For questions regarding this sample, [create a new question](https://github.com/pnp/sp-dev-fx-webparts/issues/new?assignees=&labels=Needs%3A+Triage+%3Amag%3A%2Ctype%3Aquestion%2Csample%3A%20react-script-editor&template=question.yml&sample=react-script-editor&authors=@wobba&title=react-script-editor%20-%20).
+For questions regarding this sample, [create a new question](https://github.com/pnp/sp-dev-fx-webparts/issues/new?assignees=&labels=Needs%3A+Triage+%3Amag%3A%2Ctype%3Aquestion%2Csample%3A%20react-script-editor&template=question.yml&sample=react-script-editor&authors=@wobba%20@salascz%20@felixbohnacker&title=react-script-editor%20-%20).
 
-Finally, if you have an idea for improvement, [make a suggestion](https://github.com/pnp/sp-dev-fx-webparts/issues/new?assignees=&labels=Needs%3A+Triage+%3Amag%3A%2Ctype%3Aenhancement%2Csample%3A%20react-script-editor&template=question.yml&sample=react-script-editor&authors=@wobba&title=react-script-editor%20-%20).
+Finally, if you have an idea for improvement, [make a suggestion](https://github.com/pnp/sp-dev-fx-webparts/issues/new?assignees=&labels=Needs%3A+Triage+%3Amag%3A%2Ctype%3Aenhancement%2Csample%3A%20react-script-editor&template=question.yml&sample=react-script-editor&authors=@wobba%20@salascz%20@felixbohnacker&title=react-script-editor%20-%20).
 
 ## Disclaimer
 

--- a/samples/react-script-editor/assets/sample.json
+++ b/samples/react-script-editor/assets/sample.json
@@ -9,7 +9,7 @@
       "Coming from old classic SharePoint pages you might have existing script solutions you want to re-use on a modern page without having to repackage it as a new SharePoint Framework web part."
     ],
     "creationDateTime": "2019-10-13",
-    "updateDateTime": "2023-03-11",
+    "updateDateTime": "2023-04-24",
     "products": [
       "SharePoint"
     ],
@@ -57,7 +57,17 @@
         "gitHubAccount": "felixbohnacker",
         "pictureUrl": "https://github.com/felixbohnacker.png",
         "name": "Felix Bohnacker"
-      }
+      },
+      {
+        "gitHubAccount": "salascz",
+        "name": "salascz",
+        "pictureUrl": "https://github.com/salascz.png"
+      },
+      {
+          "gitHubAccount": "wobba",
+          "name": "Mikael Svenson",
+          "pictureUrl": "https://github.com/wobba.png"
+          }
     ],
     "references": [
       {

--- a/samples/react-script-editor/config/package-solution.json
+++ b/samples/react-script-editor/config/package-solution.json
@@ -3,7 +3,7 @@
     "solution": {
         "name": "Modern Script Editor web part by mikaelsvenson",
         "id": "1425175f-3ed8-44d2-8fc4-dd1497191294",
-        "version": "1.0.21.0",
+        "version": "1.0.22.0",
         "includeClientSideAssets": true,
         "skipFeatureDeployment": false,
         "isDomainIsolated": false,

--- a/samples/react-script-editor/package-lock.json
+++ b/samples/react-script-editor/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "pnp-script-editor",
-    "version": "1.0.21",
+    "version": "1.0.22",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "pnp-script-editor",
-            "version": "1.0.21",
+            "version": "1.0.22",
             "dependencies": {
                 "@microsoft/sp-core-library": "1.16.1",
                 "@microsoft/sp-loader": "1.16.1",

--- a/samples/react-script-editor/package.json
+++ b/samples/react-script-editor/package.json
@@ -1,6 +1,6 @@
 {
     "name": "pnp-script-editor",
-    "version": "1.0.21",
+    "version": "1.0.22",
     "private": true,
     "main": "lib/index.js",
     "resolutions": {

--- a/samples/react-script-editor/src/webparts/scriptEditor/IScriptEditorWebPartProps.ts
+++ b/samples/react-script-editor/src/webparts/scriptEditor/IScriptEditorWebPartProps.ts
@@ -1,5 +1,7 @@
 export interface IScriptEditorWebPartProps {
   script: string;
+  useExternalScript: boolean;
+  externalScript?: string;
   title: string;
   removePadding: boolean;
   spPageContextInfo: boolean;


### PR DESCRIPTION
|        Q        |                    A                    |
| --------------- | --------------------------------------- |
| Bug fix?        | no                               |
| New feature?    | yes                               |
| New sample?     | no                               |
| Related issues? | - |

## What's in this Pull Request?

Modern Script Editor is popular WebPart in our company. It is being used by users for various purposes and users are making a copy of the same style/html snippet very often. It might be challenging to update such a snippet of all places at the end.

I have added an option to use an external snippet (e.g., in SiteAssets library) instead of inline html. Such a snippet can load styles common styles or even script functions for another script editors on the page (of course, user should verify such a script is loaded before calling)

The configuration has been extended with simple switch that toogle between inline editor and field for external link url
![image](https://user-images.githubusercontent.com/5662939/233990926-492fafe0-1519-4610-b891-9e7a7920ff2b.png)
![image](https://user-images.githubusercontent.com/5662939/233990995-560a4a42-1cf3-4c3f-8fc9-8635d027d00f.png)

- The root part of the WebPart (actual conversion of html snippet) was not affected.
- Inline is the default behaviour and changes are back-compatible

Thanks