### PR TITLE
Use treeFrom/treeExpandTo settings only in "tree" mode

### DIFF
--- a/samples/react-pages-hierarchy/README.md
+++ b/samples/react-pages-hierarchy/README.md
@@ -1,5 +1,5 @@
 
-(# Pages Hierarchy
+# Pages Hierarchy
 
 ## Summary
 

--- a/samples/react-pages-hierarchy/README.md
+++ b/samples/react-pages-hierarchy/README.md
@@ -1,4 +1,5 @@
-# Pages Hierarchy
+
+(# Pages Hierarchy
 
 ## Summary
 
@@ -35,8 +36,8 @@ This web part allows users to create a faux page hierarchy in their pages librar
 
 ## Contributors
 
-* [Bo George](https://github.com/bogeorge) ([@bo_george](https://twitter.com/bo_george))
-* [Nick Brown](https://github.com/techienickb) ([@techienickb](https://twitter.com/techienickb))
+* [Bo George](https://github.com/bogeorge)
+* [Nick Brown](https://github.com/techienickb) 
 * [SlowRobot](https://github.com/SlowRobot)
 * [ruslan-s](https://github.com/ruslan-s)
 
@@ -49,6 +50,7 @@ Version|Date|Comments
 1.3|March 31, 2022|Added a Tree View
 1.4|July 29, 2022|Updated Tree View Functionality
 1.5|March 29, 2023|Added support for non-English SitePages library paths
+1.6|May 11, Uses treeFrom/expandTo web part properties
 
 ## Minimal path to awesome
 

--- a/samples/react-pages-hierarchy/assets/sample.json
+++ b/samples/react-pages-hierarchy/assets/sample.json
@@ -9,7 +9,7 @@
       "This web part allows users to create a faux page hierarchy in their pages library and use it for page-to-page navigation."
     ],
     "creationDateTime": "2020-04-30",
-    "updateDateTime": "2023-03-29",
+    "updateDateTime": "2023-05-11",
     "products": [
       "SharePoint"
     ],
@@ -53,7 +53,12 @@
           "gitHubAccount": "ruslan-s",
           "name": "ruslan-s",
           "pictureUrl": "https://github.com/ruslan-s.png"
-      }
+      },
+      {
+          "gitHubAccount": "SlowRobot",
+          "name": "SlowRobot",
+          "pictureUrl": "https://github.com/SlowRobot.png"
+          }
     ],
     "references": [
       {

--- a/samples/react-pages-hierarchy/config/package-solution.json
+++ b/samples/react-pages-hierarchy/config/package-solution.json
@@ -4,7 +4,7 @@
     "name": "react-pages-hierarchy",
     "id": "89758fb6-85e2-4e2b-ac88-4f4e7e5f60cb",
     "title": "Pages Hierarchy",
-    "version": "1.0.3.1",
+    "version": "1.0.3.2",
     "includeClientSideAssets": true,
     "isDomainIsolated": false,
     "developer": {

--- a/samples/react-pages-hierarchy/src/apiHooks/usePageApi.ts
+++ b/samples/react-pages-hierarchy/src/apiHooks/usePageApi.ts
@@ -88,7 +88,7 @@ function pagesReducer(state: PagesState, action: Action): PagesState {
   }
 }
 
-export function usePageApi(currentPageId: number, pageEditFinished: boolean, context: WebPartContext, treeTop: number, treeExpandTo: number): PageApi {
+export function usePageApi(currentPageId: number, pageEditFinished: boolean, context: WebPartContext, treeTop?: number, treeExpandTo?: number): PageApi {
   const [pagesState, pagesDispatch] = useReducer(pagesReducer, {
     parentPageColumnExists: true,
     userCanManagePages: false,

--- a/samples/react-pages-hierarchy/src/webparts/pagehierarchy/components/Container/Container.tsx
+++ b/samples/react-pages-hierarchy/src/webparts/pagehierarchy/components/Container/Container.tsx
@@ -10,7 +10,10 @@ import { Placeholder } from "@pnp/spfx-controls-react/lib/Placeholder";
 import { TreeLayout } from '../Layouts/TreeLayout';
 
 export const Container: React.FunctionComponent<IContainerProps> = props => {
-  const pagesApi = usePageApi(props.currentPageId, props.pageEditFinished, props.context, props.treeFrom, props.treeExpandTo);
+  // Use props.treeFrom / treeExpandTo value from settings only in display mode "tree"
+  const treeFrom = (props.pagesToDisplay === PagesToDisplay.Tree) ? props.treeFrom : undefined;
+  const treeExpandTo = (props.pagesToDisplay === PagesToDisplay.Tree) ? props.treeExpandTo : undefined;
+  const pagesApi = usePageApi(props.currentPageId, props.pageEditFinished, props.context, treeFrom, treeExpandTo);
   let controlToRender = undefined;
   switch (props.pagesToDisplay) {
     case PagesToDisplay.Ancestors:


### PR DESCRIPTION
Fix for https://github.com/pnp/sp-dev-fx-webparts/issues/3684

> By submitting this pull request, you agree to the [contribution guidelines](https://github.com/pnp/sp-dev-fx-webparts/blob/main/CONTRIBUTING.md)

> If you aren't familiar with how to contribute to open-source repositories using GitHub, or if you find the instructions on this page confusing, [sign up](https://forms.office.com/Pages/ResponsePage.aspx?id=KtIy2vgLW0SOgZbwvQuRaXDXyCl9DkBHq4A2OG7uLpdUREZVRDVYUUJLT1VNRDM4SjhGMlpUNzBORy4u) for one of our [Sharing is Caring](https://pnp.github.io/sharing-is-caring/#pnp-sic-events) events. It's completely free, and we'll guide you through the process.

> To submit a pull request with multiple authors, make sure that at least one commit is a co-authored commit by adding a `Co-authored-by:` trailer to the commit's message. E.g.: `Co-authored-by: name <name@example.com>`

|        Q        |                    A                    |
| --------------- | --------------------------------------- |
| Bug fix?        | yes                               |
| New feature?    | no                               |
| New sample?     | no                               |
| Related issues? | fixes #3684 |

## What's in this Pull Request?

It's a fix for https://github.com/pnp/sp-dev-fx-webparts/issues/3684. The treeFrom/treeExpandTo web part settings should only be used in "tree" mode. Otherwise if may break in sites where there is no page with item id "1" that is the default value.



