### PR TITLE
Update GetAnchorUrl  in SPService.ts

### DIFF
--- a/samples/react-page-navigator/.devcontainer/devcontainer.json
+++ b/samples/react-page-navigator/.devcontainer/devcontainer.json
@@ -1,7 +1,7 @@
 // For more information on how to run this SPFx project in a VS Code Remote Container, please visit https://aka.ms/spfx-devcontainer
 {
-	"name": "SPFx 1.12.1",
-	"image": "docker.io/m365pnp/spfx:1.12.1",
+	"name": "SPFx 1.14.1",
+	"image": "docker.io/m365pnp/spfx:1.14.1",
 	// Set *default* container specific settings.json values on container create.
 	"settings": {},
 	// Add the IDs of extensions you want installed when the container is created.

--- a/samples/react-page-navigator/README.md
+++ b/samples/react-page-navigator/README.md
@@ -36,6 +36,7 @@ Version|Date|Comments
 1.5|July 19, 2022|Bug fixes
 1.6|August 8, 2022|Add theme provider and bug fixes
 1.7|December 22, 2022|Fixed issue with duplicated level 2 headings
+1.8|May 13, 2023|Fixed issue when heading has a + symbol
 
 ## Minimal Path to Awesome
 
@@ -54,6 +55,7 @@ Version|Date|Comments
 
 * [Aakash Bhardwaj](https://github.com/aakashbhardwaj619)
 * [Jasey Waegebaert](https://github.com/Jwaegebaert)
+* [Mike Zimmerman](https://github.com/mikezimm)
 
 ## Help
 

--- a/samples/react-page-navigator/assets/sample.json
+++ b/samples/react-page-navigator/assets/sample.json
@@ -9,7 +9,7 @@
       "This web part fetches all the automatically added Header anchor tags in a SharePoint page and displays them in a Navigation component."
     ],
     "creationDateTime": "2019-09-05",
-    "updateDateTime": "2023-01-20",
+    "updateDateTime": "2023-05-23",
     "products": [
       "SharePoint"
     ],
@@ -43,7 +43,12 @@
         "gitHubAccount": "Jwaegebaert",
         "pictureUrl": "https://github.com/Jwaegebaert.png",
         "name": "Jasey Waegebaert"
-      }
+      },
+      {
+          "gitHubAccount": "mikezimm",
+          "name": "Mike Zimmerman",
+          "pictureUrl": "https://github.com/mikezimm.png"
+          }
     ],
     "references": [
       {

--- a/samples/react-page-navigator/src/Service/SPService.ts
+++ b/samples/react-page-navigator/src/Service/SPService.ts
@@ -15,10 +15,11 @@ export class SPService {
   private static GetAnchorUrl(headingValue: string): string {
     let anchorUrl = `#${headingValue
       .toLowerCase()
-      .replace(/[{}|\[\]\<\>#@"'^%`?;:\/=~\\\s\s+]/g, " ")
+      .replace(/[{}|\[\]\<\>#@"'^%`?;:\/=~\\\s\s]/g, " ")
       .replace(/^(-|\s)*|(-|\s)*$/g, "")
       .replace(/\'|\?|\\|\/| |\&/g, "-")
       .replace(/-+/g, "-")
+      .replace(/[+]/g, "%2B") // https://github.com/pnp/sp-dev-fx-webparts/issues/3686
       .substring(0, 128)}`;
 
     let counter = 1;


### PR DESCRIPTION
Solve issue:  
https://github.com/pnp/sp-dev-fx-webparts/issues/3686

fix GetAnchorUrl so it creates correct anchorlink when heading has a + symbol.

|        Q        |                    A                    |
| --------------- | --------------------------------------- |
| Bug fix?        |  yes                           |
| New feature?    | no                             |
| New sample?     | no                           |
| Related issues? | fixes #3686 |

## What's in this Pull Request?
Update GetAnchorUrl  in SPService.ts
https://github.com/pnp/sp-dev-fx-webparts/issues/3686

Update regex so that it replaces + symbol with `%2B` characters

