### PR TITLE
react-rss-reader - Fixed loading message not disappearing when RSS feed is empty

### DIFF
--- a/samples/react-rss-reader/README.md
+++ b/samples/react-rss-reader/README.md
@@ -61,6 +61,7 @@ Version|Date|Comments
 1.0.4 | May 25, 2023 | Fixed direct request issues
 1.1.0 | February 6, 2024 | Upgraded to SPFx 1.18.2
 1.2.0 | October 30, 2024 | Upgraded to SPFx 1.20.0
+1.2.1 | November 20, 2024 | Fixed a bug where loading message doesn't disappear when RSS feed doesn't contain any items.
 
 ## Minimal Path to Awesome
 
@@ -74,7 +75,7 @@ Version|Date|Comments
   - `npm install`
   - `gulp serve`
 
-- To bundle and package the installable *.sppkg*, run:
+- To bundle and package the installable `.sppkg`, run:
   - `gulp bundle --ship`
   - `gulp package-solution --ship`
 

--- a/samples/react-rss-reader/assets/sample.json
+++ b/samples/react-rss-reader/assets/sample.json
@@ -9,7 +9,7 @@
       "A RSS Reader original based on work completed by Olivier Carpentier\u0027s"
     ],
     "creationDateTime": "2020-11-22",
-    "updateDateTime": "2024-10-30",
+    "updateDateTime": "2024-11-20",
     "products": [
       "SharePoint"
     ],

--- a/samples/react-rss-reader/src/services/RssXmlParserService/rssXmlParserService.ts
+++ b/samples/react-rss-reader/src/services/RssXmlParserService/rssXmlParserService.ts
@@ -161,7 +161,7 @@ export class RssXmlParserService {
 
   public static buildRSS2(xmlObj: any): void {
     const channel:any = Array.isArray(xmlObj.rss.channel) ? xmlObj.rss.channel[0] : xmlObj.rss.channel;
-    const items = Array.isArray(channel.item) ? channel.item : [channel.item];
+    const items = Array.isArray(channel.item) || !channel.item ? channel.item : [channel.item];
     const feed = this.buildRSS(channel, items);
     if (xmlObj.rss.$ && xmlObj.rss.$['xmlns:itunes']) {
       this.decorateItunes(feed, channel);


### PR DESCRIPTION
- [ ] New sample
- [x] Bug fix/update
- [ ] Related issues

## What's in this Pull Request?

Fixed a bug where loading message doesn't disappear when RSS feed doesn't contain any items.

## Node Version

Node version used: v18.20.5

## Checklist

- [x] My pull request affects only ONE sample.
- [ ] My sample builds without any warnings
- [ ] I have updated the `README.md` file's **Version history**. For new samples, created a new `README.md` file matching [this template](templates/README-template.md)
- [ ] My `README.md` has at least one static high-resolution screenshot (i.e. not a GIF) located in the `assets` folder.
- [ ] My `README.md` contains complete setup instructions, including pre-requisites and permissions required
- [ ] My solution includes a `.nvmrc` file indicating the version of Node.js