### PR TITLE
M365 Planner Timeline Fix to Asset Image URL in sample.json

### DIFF
--- a/samples/react-M365-Planner-Timeline/assets/sample.json
+++ b/samples/react-M365-Planner-Timeline/assets/sample.json
@@ -29,7 +29,7 @@
         "name": "webParts.png",
         "type": "image",
         "order": 100,
-        "url": "https://github.com/pnp/sp-dev-fx-webparts/raw/main/samples/react-m365-planner-timeline/assets/webParts.png",
+        "url": "https://github.com/pnp/sp-dev-fx-webparts/blob/main/samples/react-M365-Planner-Timeline/assets/webParts.png?raw=true",
         "alt": "Web Part Preview"
       }
     ],


### PR DESCRIPTION
- [ ] New sample
- [x] Bug fix/update
- [ ] Related issues: fixes #X, partially #Y, mentioned in #Z


## What's in this Pull Request?

Fix to the image URL in sample.json

## Node Version

Node version used: v18.20.3

## Checklist

- [x] My pull request affects only ONE sample.
- [x] My sample builds without any warnings
- [ ] I have updated the `README.md` file's **Version history**. For new samples, created a new `README.md` file matching [this template](templates/README-template.md)
- [ ] My `README.md` has at least one static high-resolution screenshot (i.e. not a GIF) located in the `assets` folder.
- [ ] My `README.md` contains complete setup instructions, including pre-requisites and permissions required
- [ ] My solution includes a `.nvmrc` file indicating the version of Node.js

## Submitter Guidance (DELETE AFTER READING)

The sample gallery does not render the image from the sample.json file. I have update the URL to fix. 

