### PR TITLE
Fix Bug Display Content type name - react-list-search

### DIFF
--- a/samples/react-list-search/README.md
+++ b/samples/react-list-search/README.md
@@ -4,14 +4,21 @@
 
 This list search web part allows the user to show data from lists or libraries. The web part can be used to (for more details see images below):
 
-  * [Show merged items from different lists/libraries](#merge-items-from-different-listslibraries)
-  * [Open item data in modal window (same data shown in the table)](#merge-items-from-different-listslibraries)
-  * [Select render by field type](#select-render-of-the-selected-fields)
-  * [Open item detail in modal window (it allows to select the fields to show by list)](#open-selected-item-with-selected-properties)
-  * [Open documents in modal window](#open-documents-in-modal-window)
-  * [Open documents in new tab](#open-documents-in-new-tab)
-  * [Use of dynamic data](#use-of-dynamic-data)
-  * [Redirect to url](#redirect-to-url-depends-on-selected-item)
+  [Show merged items from different lists/libraries](#merge-items-from-different-listslibraries)
+
+  [Open item data in modal window (same data shown in the table)](#merge-items-from-different-listslibraries)
+
+  [Select render by field type](#select-render-of-the-selected-fields)
+
+  [Open item detail in modal window (it allows to select the fields to show by list)](#open-selected-item-with-selected-properties)
+
+  [Open documents in modal window](#open-documents-in-modal-window)
+
+  [Open documents in new tab](#open-documents-in-new-tab)
+
+  [Use of dynamic data](#use-of-dynamic-data)
+  
+  [Redirect to url](#redirect-to-url-depends-on-selected-item)
 
 * Other useful functionalities:
   * List item modern audience support
@@ -91,6 +98,7 @@ Version|Date|Comments
 1.2.0|January 01, 2022|Upgraded for SPFx v1.13.1
 1.3.0|July 11, 2022|Fixes CAML issues
 1.4.0|October 2, 2024|Upgraded for SPFx v1.20.0
+1.5.0|August 14, 2025|Fixes ContentType query
 
 ## Minimal Path to Awesome
 
@@ -105,12 +113,6 @@ Version|Date|Comments
     * `gulp serve`
     * Open the *workbench* on your Office 365 Developer tenant
     * Test out the web part
-
-### Sppkg
-
-  * Download `.sppkg` files from `sppkg` folder
-  * Upload files to **App Catalog**
-  * Approve the API permissions in the new SP admin center (only needed if you are going to enable list item modern audience)
 
 ## Features
 

--- a/samples/react-list-search/config/package-solution.json
+++ b/samples/react-list-search/config/package-solution.json
@@ -3,7 +3,7 @@
   "solution": {
     "name": "list-search-webpart",
     "id": "8277f088-9c30-4f95-9c15-9c18a9d40a26",
-    "version": "1.4.0.1",
+    "version": "1.5.0.0",
     "includeClientSideAssets": true,
     "skipFeatureDeployment": true,
     "isDomainIsolated": false,

--- a/samples/react-list-search/config/package-solution.json
+++ b/samples/react-list-search/config/package-solution.json
@@ -3,7 +3,7 @@
   "solution": {
     "name": "list-search-webpart",
     "id": "8277f088-9c30-4f95-9c15-9c18a9d40a26",
-    "version": "1.4.0.0",
+    "version": "1.4.0.1",
     "includeClientSideAssets": true,
     "skipFeatureDeployment": true,
     "isDomainIsolated": false,

--- a/samples/react-list-search/src/webparts/listSearch/ListSearchWebPart.ts
+++ b/samples/react-list-search/src/webparts/listSearch/ListSearchWebPart.ts
@@ -761,7 +761,7 @@ export default class ListSearchWebPart extends BaseClientSideWebPart<IListSearch
           title: strings.CollectionDataFieldsRenderType,
           type: CustomCollectionFieldType.custom,
           required: true,
-          onCustomRender: (field, value, onUpdate, item) => {
+          onCustomRender: (field, value, onUpdate, item: IBaseFieldData) => {
             if (item.SiteCollectionSource && item.ListSourceField && item.SourceField) {
               return (
                 CustomCollectionDataField.getPickerByStringOptions(this.GetRenderOptionsByType(item.SPFieldType), field, item, onUpdate, undefined)
@@ -1032,7 +1032,7 @@ export default class ListSearchWebPart extends BaseClientSideWebPart<IListSearch
                       title: strings.CollectionDataFieldsRenderType,
                       type: CustomCollectionFieldType.custom,
                       required: true,
-                      onCustomRender: (field, value, onUpdate, item) => {
+                      onCustomRender: (field, value, onUpdate, item: IMappingFieldData) => {
                         if (item.SiteCollectionSource && item.ListSourceField && item.SourceField) {
                           return (
                             CustomCollectionDataField.getPickerByStringOptions(this.GetRenderOptionsByType(item.SPFieldType), field, item, onUpdate, undefined)
@@ -1166,6 +1166,11 @@ export default class ListSearchWebPart extends BaseClientSideWebPart<IListSearch
   private GetRenderOptionsByType(SPFieldType: string): string[] {
     let result = [SPFieldType];
     switch (SPFieldType) {
+      case SharePointType.Computed:
+        {
+          result = [SharePointType.Computed];
+          break;
+        }
       case SharePointType.Text:
       case SharePointType.Note:
       case SharePointType.NoteFullHtml:

--- a/samples/react-list-search/src/webparts/listSearch/components/ListSearch.tsx
+++ b/samples/react-list-search/src/webparts/listSearch/components/ListSearch.tsx
@@ -49,6 +49,7 @@ import { WebPartTitle } from "@pnp/spfx-controls-react/lib/WebPartTitle";
 import GraphService from '../services/GraphService';
 import { List } from 'lodash';
 import { getKeyValue } from '../utils/ObjectUtils';
+import { IBaseFieldData } from '../model/IListConfigProps';
 
 
 const LOG_SOURCE = "IListdSearchWebPart";
@@ -165,7 +166,7 @@ export default class IListdSearchWebPart extends React.Component<IListSearchProp
     const columns: IColumn[] = [];
     this.props.detailListFieldsCollectionData.sort().map(column => {
       const mappingType = this.props.mappingFieldsCollectionData.find(e => e.TargetField === column.ColumnTitle);
-      columns.push({ key: column.ColumnTitle, name: column.ColumnTitle, fieldName: column.ColumnTitle, minWidth: column.MinColumnWidth || 50, maxWidth: column.MaxColumnWidth, isResizable: true, data: mappingType ? mappingType.SPFieldType : (column.IsFileIcon ? SharePointType.FileIcon : SharePointType.Text), onColumnClick: this._onColumnClick, isIconOnly: column.IsFileIcon });
+      columns.push({ key: column.ColumnTitle, name: column.ColumnTitle, fieldName: column.ColumnTitle, minWidth: column.MinColumnWidth || 50, maxWidth: column.MaxColumnWidth, isResizable: true, data: mappingType ? mappingType : (column.IsFileIcon ? SharePointType.FileIcon : SharePointType.Text), onColumnClick: this._onColumnClick, isIconOnly: column.IsFileIcon });
     });
 
     return columns;
@@ -333,10 +334,10 @@ export default class IListdSearchWebPart extends React.Component<IListSearchProp
     if (this.props.IndividualColumnFilter) {
       const _renderDetailsFooterItemColumn: IDetailsRowBaseProps['onRenderItemColumn'] = (item, index, column) => {
         const filter: IColumnFilter = this.state.columnFilters.find(colFilter => colFilter.columnName == column.name);
-        if (this.props.IndividualColumnFilter && showSearchBox && column.data != SharePointType.FileIcon) {
+        if (this.props.IndividualColumnFilter && showSearchBox && column.data.SPFieldType != SharePointType.FileIcon) {
           return (
             <SearchBox placeholder={column.name} iconProps={filterIcon} value={filter ? filter.filterToApply : ""}
-              underlined={true} onChange={(_, value) => this.filterColumnListItems(column.name, value, column.data)} onClear={() => this.filterColumnListItems(column.name, "", SharePointType.Text)} />
+              underlined={true} onChange={(_, value) => this.filterColumnListItems(column.name, value, column.data.SPFieldType)} onClear={() => this.filterColumnListItems(column.name, "", SharePointType.Text)} />
           );
         }
         else {
@@ -521,7 +522,7 @@ export default class IListdSearchWebPart extends React.Component<IListSearchProp
                     <div className={styles.propertyModal}>
                       {val.TargetField}
                     </div>
-                    {this.GetModalBodyRenderByFieldType(this.state.selectedItem, val.TargetField, val.SPFieldType)}
+                    {this.GetModalBodyRenderByFieldType(this.state.selectedItem, val.TargetField, val)}
                   </>;
                 })
             }
@@ -538,7 +539,7 @@ export default class IListdSearchWebPart extends React.Component<IListSearchProp
                     {val.TargetField}
                   </div>
                   <div>
-                    {this.state.isModalLoading ? <Shimmer /> : this.GetModalBodyRenderByFieldType(this.state.completeModalItemData, val.SourceField, val.SPFieldType)}
+                    {this.state.isModalLoading ? <Shimmer /> : this.GetModalBodyRenderByFieldType(this.state.completeModalItemData, val.SourceField, val)}
                   </div>
                 </>;
               })
@@ -602,10 +603,10 @@ export default class IListdSearchWebPart extends React.Component<IListSearchProp
   }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  private GetModalBodyRenderByFieldType(item: any, propertyName: string, fieldType: SharePointType): JSX.Element {
-    let result = this.GetJSXElementByType(item, propertyName, fieldType, true);
+  private GetModalBodyRenderByFieldType(item: any, propertyName: string, data: IBaseFieldData): JSX.Element {
+    let result = this.GetJSXElementByType(item, propertyName, data, true);
 
-    switch (fieldType) {
+    switch (data.SPFieldType) {
       case SharePointType.Boolean:
         result = <Toggle checked={item[propertyName]} />;
         break;
@@ -693,11 +694,11 @@ export default class IListdSearchWebPart extends React.Component<IListSearchProp
   }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  private GetJSXElementByType(item: any, fieldName: string, fieldType: SharePointType, ommitCamlQuery = false): JSX.Element {
-    const value = this.GetItemValueFieldByFieldType(item, fieldName, fieldType, ommitCamlQuery);
+  private GetJSXElementByType(item: any, fieldName: string, data: IBaseFieldData, ommitCamlQuery = false): JSX.Element {
+    const value = this.GetItemValueFieldByFieldType(item, fieldName, data.SPFieldType, ommitCamlQuery);
     const { semanticColors }: IReadonlyTheme = this.props.themeVariant;
-    let result: JSX.Element = <span/>;
-    switch (fieldType) {
+    let result: JSX.Element = <span />;
+    switch (data.SPFieldType) {
       case SharePointType.FileIcon:
         {
           result = this.GetFileIconByFileType(value);
@@ -721,7 +722,7 @@ export default class IListdSearchWebPart extends React.Component<IListSearchProp
               />;
             }
             else {
-              result = <span/>;
+              result = <span />;
             }
           }
           break;
@@ -735,7 +736,7 @@ export default class IListdSearchWebPart extends React.Component<IListSearchProp
                 return <span key={index} style={{ color: semanticColors.bodyText }}>{val}</span>;
               }
               else {
-                return <span key={index} style={{ color: semanticColors.bodyText }}>{val}<br/></span>;
+                return <span key={index} style={{ color: semanticColors.bodyText }}>{val}<br /></span>;
               }
             })}
             </span>;
@@ -755,7 +756,7 @@ export default class IListdSearchWebPart extends React.Component<IListSearchProp
               />;
             }
             else {
-              result = <span/>;
+              result = <span />;
             }
           }
           break;
@@ -766,16 +767,16 @@ export default class IListdSearchWebPart extends React.Component<IListSearchProp
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
             result = <span>{value.map((val: any, index: number) => {
               if (index + 1 == value.length) {
-                return <span key={`${fieldType}-${index}`} style={{ color: semanticColors.bodyText }}>{val}</span>;
+                return <span key={`${data.SPFieldType}-${index}`} style={{ color: semanticColors.bodyText }}>{val}</span>;
               }
               else {
-                return <span key={`${fieldType}-${index}`} style={{ color: semanticColors.bodyText }}>{val}<br/></span>;
+                return <span key={`${data.SPFieldType}-${index}`} style={{ color: semanticColors.bodyText }}>{val}<br /></span>;
               }
             })}
             </span>;
           }
           else {
-            result = <span/>;
+            result = <span />;
           }
           break;
         }
@@ -784,7 +785,7 @@ export default class IListdSearchWebPart extends React.Component<IListSearchProp
           result = <Link style={{ color: semanticColors.bodyText }} href="#">{value}</Link>;
         }
         else {
-          result = <span/>;
+          result = <span />;
         }
         break;
       case SharePointType.ChoiceMulti:
@@ -792,16 +793,16 @@ export default class IListdSearchWebPart extends React.Component<IListSearchProp
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           result = <span>{value.map((val: any, index: number) => {
             if (index + 1 == value.length) {
-              return <span key={`${fieldType}-${index}`} style={{ color: semanticColors.bodyText }}>{val}</span>;
+              return <span key={`${data.SPFieldType}-${index}`} style={{ color: semanticColors.bodyText }}>{val}</span>;
             }
             else {
-              return <span key={`${fieldType}-${index}`} style={{ color: semanticColors.bodyText }}>{val}<br/></span>;
+              return <span key={`${data.SPFieldType}-${index}`} style={{ color: semanticColors.bodyText }}>{val}<br /></span>;
             }
           })}
           </span>;
         }
         else {
-          result = <span/>;
+          result = <span />;
         }
         break;
       case SharePointType.LookupMulti:
@@ -809,16 +810,16 @@ export default class IListdSearchWebPart extends React.Component<IListSearchProp
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           result = <span>{value.map((val: any, index: number) => {
             if (index + 1 == value.length) {
-              return <Link key={`${fieldType}-${index}`} style={{ color: semanticColors.bodyText }} href="#">{val}</Link>;
+              return <Link key={`${data.SPFieldType}-${index}`} style={{ color: semanticColors.bodyText }} href="#">{val}</Link>;
             }
             else {
-              return <span key={`${fieldType}-${index}`}><Link style={{ color: semanticColors.bodyText }} href="#">{val}</Link><br/></span>;
+              return <span key={`${data.SPFieldType}-${index}`}><Link style={{ color: semanticColors.bodyText }} href="#">{val}</Link><br /></span>;
             }
           })}
           </span>;
         }
         else {
-          result = <span/>;
+          result = <span />;
         }
         break;
       case SharePointType.Url:
@@ -826,7 +827,7 @@ export default class IListdSearchWebPart extends React.Component<IListSearchProp
           result = <Link href={value.Url} style={{ color: semanticColors.bodyText }}>{value.Description}</Link>;
         }
         else {
-          result = <span/>;
+          result = <span />;
         }
         break;
       case SharePointType.Image:
@@ -846,20 +847,29 @@ export default class IListdSearchWebPart extends React.Component<IListSearchProp
             />;
           }
           else {
-            result = <span/>;
+            result = <span />;
           }
           break;
         }
       case SharePointType.NoteFullHtml:
         {
           if (value) {
-            result = <span dangerouslySetInnerHTML={{ __html: value }}/>;
+            result = <span dangerouslySetInnerHTML={{ __html: value }} />;
           }
           else {
-            result = <span/>;
+            result = <span />;
           }
           break;
         }
+      case SharePointType.Computed:
+        if (data.SourceField === "ContentType") {
+          result = <span style={{ color: semanticColors.bodyText }}>{value.Name}</span>;
+        }
+        else {
+          result = <span style={{ color: semanticColors.bodyText }}>{value}</span>;
+        }
+
+        break;
       default:
         result = <span style={{ color: semanticColors.bodyText }}>{value}</span>;
         break;
@@ -1085,7 +1095,7 @@ export default class IListdSearchWebPart extends React.Component<IListSearchProp
       <div className={styles.listSearch} style={{ backgroundColor: semanticColors.bodyBackground, color: semanticColors.bodyText }}>
         <div className={styles.row}>
           <div className={styles.column}>
-            <WebPartTitle title={this.props.title} updateProperty={(value: string) => this.props.updateTitle(value)} displayMode={this.props.displayMode} placeholder={strings.WebPartTitlePlaceHolder}/>
+            <WebPartTitle title={this.props.title} updateProperty={(value: string) => this.props.updateTitle(value)} displayMode={this.props.displayMode} placeholder={strings.WebPartTitlePlaceHolder} />
             {this.state.errorMsg ?
               <MessageBar
                 messageBarType={MessageBarType.error}

--- a/samples/react-list-search/src/webparts/listSearch/model/ISharePointFieldTypes.ts
+++ b/samples/react-list-search/src/webparts/listSearch/model/ISharePointFieldTypes.ts
@@ -95,6 +95,10 @@ export class SharePointFieldTypes {
         result = SharePointType.Guid;
         break;
       }
+      case 'Computed': {
+        result = SharePointType.Computed;
+        break;
+      }
       default: {
         result = SharePointType.Text;
       }

--- a/samples/react-list-search/src/webparts/listSearch/services/ListService.ts
+++ b/samples/react-list-search/src/webparts/listSearch/services/ListService.ts
@@ -163,6 +163,21 @@ export default class ListService {
     let hasToAddFieldsAsText = false;
     listQueryOptions.fields.map(field => {
       switch (field.fieldType) {
+        case SharePointType.Computed:
+          if (field.originalField === "ContentType") {
+            if (isCamlQuery) {
+              hasToAddFieldsAsText = true;
+              result.viewFields.push(field.originalField);
+            }
+            else {
+              result.viewFields.push(`${field.originalField}/Name`);
+              result.expandFields.push(`${field.originalField}`);
+            }
+          }
+          else {
+            result.viewFields.push(field.originalField);
+          }
+          break;
         case SharePointType.User:
         case SharePointType.UserEmail:
         case SharePointType.UserName:
@@ -228,6 +243,17 @@ export default class ListService {
 
   private GetItemValue(item: IResult, field: IListSearchListQueryItem, fromCamlQuery: boolean): IResult {
     switch (field.fieldType) {
+      case SharePointType.Computed:
+        if (fromCamlQuery) {
+          item[field.newField] = item['FieldValuesAsText'][field.originalField];
+        }
+        else {
+          item[field.newField] = item[field.originalField];
+          if (field.newField !== field.originalField) {
+            delete item[field.originalField];
+          }
+        }
+        break;
       case SharePointType.Lookup:
       case SharePointType.LookupMulti:
         if (fromCamlQuery) {


### PR DESCRIPTION

- [ ] New sample
- [x] Bug fix/update
- [x] Related issues: fixes #5517 


## What's in this Pull Request?
Fixed issue #5517 - The component correctly retrieves the name of the content type.

## Node Version
18.19.0

## Checklist

> This checklist is used to automatically pre-process your pull request; It is meant to help process pull requests in a timely manner, rather than hoops to jump through.
> 
> Put an `x` in all the items that apply (`[x]`, no spaces between the `[`, the `x`, and the `]` ). Make notes next to any that haven't been addressed.

- [x] My pull request affects only ONE sample.
- [x] My sample builds without any warnings
- [x] I have updated the `README.md` file's **Version history**. For new samples, created a new `README.md` file matching [this template](templates/README-template.md)
- [x] My `README.md` has at least one static high-resolution screenshot (i.e. not a GIF) located in the `assets` folder.
- [x] My `README.md` contains complete setup instructions, including pre-requisites and permissions required
- [x] My solution includes a `.nvmrc` file indicating the version of Node.js




