### PR TITLE
Fix invalid recurrence XML generation in applyRecurrence() method

### DIFF
--- a/samples/react-calendar/src/controls/EventRecurrenceInfoDaily/EventRecurrenceInfoDaily.tsx
+++ b/samples/react-calendar/src/controls/EventRecurrenceInfoDaily/EventRecurrenceInfoDaily.tsx
@@ -295,10 +295,14 @@ export class EventRecurrenceInfoDaily extends React.Component<IEventRecurrenceIn
         break;
     }
     const recurrenceXML = `<recurrence><rule><firstDayOfWeek>su</firstDayOfWeek><repeat>` +
-      `<daily ${ this.state.selectPatern === 'every' ? `dayFrequency="${this.state.numberOfDays.trim()}"/>` : 'weekday'}</repeat>${selectDateRangeOption}</rule></recurrence>`;
-  //  console.log(recurrenceXML);
+    (this.state.selectPatern === 'every'
+      ? `<daily dayFrequency="${this.state.numberOfDays.trim()}"/>`
+      : `<daily weekday="TRUE"/>`
+    ) +
+    `</repeat>${selectDateRangeOption}</rule></recurrence>`;
+  
     this.props.returnRecurrenceData(this.state.startDate, recurrenceXML);
-  }
+    }
   /**
    *
    *


### PR DESCRIPTION
> By submitting this pull request, you agree to the [contribution guidelines](https://github.com/pnp/sp-dev-fx-webparts/blob/main/CONTRIBUTING.md)

> If you aren't familiar with how to contribute to open-source repositories using GitHub, or if you find the instructions on this page confusing, [sign up](https://forms.office.com/Pages/ResponsePage.aspx?id=KtIy2vgLW0SOgZbwvQuRaXDXyCl9DkBHq4A2OG7uLpdUREZVRDVYUUJLT1VNRDM4SjhGMlpUNzBORy4u) for one of our [Sharing is Caring](https://pnp.github.io/sharing-is-caring/#pnp-sic-events) events. It's completely free, and we'll guide you through the process.

> To submit a pull request with multiple authors, make sure that at least one commit is a co-authored commit by adding a `Co-authored-by:` trailer to the commit's message. E.g.: `Co-authored-by: name <name@example.com>`

> Put an `x` in all the items that apply (`[x]`, no spaces between the `[`, the `x`, and the `]` ), make notes next to any that haven't been addressed.

- [ ] New sample
- [x] Bug fix/update
- [ ] Related issues: fixes #X, partially #Y, mentioned in #Z


## What's in this Pull Request?

This PR fixes a bug in the `applyRecurrence()` method where the generated recurrence XML was invalid for some options.  
The issue caused broken `<daily>` tags, so SharePoint couldn’t read the recurrence data correctly when saving or updating events.

### Root Cause
The `<daily>` tag was not built properly — it was missing attributes or not closed correctly when the pattern wasn’t `"every"`.

### Fix
Updated the XML generation logic to always create a valid `<daily>` element for both “every N days” and “weekdays only” options.

---

## Node Version
> (Use `node -v` to get the version of Node you used to build this sample)

Node version used: **v18.20.8**

## Checklist

> This checklist is used to automatically pre-process your pull request; It is meant to help process pull requests in a timely manner, rather than hoops to jump through.
> 
> Put an `x` in all the items that apply (`[x]`, no spaces between the `[`, the `x`, and the `]` ). Make notes next to any that haven't been addressed.

- [x] My pull request affects only ONE sample.
- [x] My sample builds without any warnings
- [x] I have updated the `README.md` file's **Version history**. For new samples, created a new `README.md` file matching [this template](templates/README-template.md)
- [x] My `README.md` has at least one static high-resolution screenshot (i.e. not a GIF) located in the `assets` folder.
- [x] My `README.md` contains complete setup instructions, including pre-requisites and permissions required
- [x] My solution includes a `.nvmrc` file indicating the version of Node.js




