### PR TITLE
Fixes `sample.json` of react office breakout sample

### DIFF
--- a/samples/react-office-breakout/assets/sample.json
+++ b/samples/react-office-breakout/assets/sample.json
@@ -26,7 +26,6 @@
       {
         "key": "SPFX-VERSION",
         "value": "1.21.1"
-        "value": "1.21.1"
       }
     ],
     "thumbnails": [


### PR DESCRIPTION
- [ ] New sample
- [x] Bug fix/update
- [ ] Related issues: fixes #X, partially #Y, mentioned in #Z

## What's in this Pull Request?

The aim is to introduce a small fix on the `sample.json` of the react office breakout sample in order to solve a bug we get in SPFx Toolkit extension when synchornizing samples to the VS Code extension gallery. https://github.com/pnp/vscode-viva/issues/624