### PR TITLE
docs: clarify visitor stats badge must use HTML <img> tag, not Markdown syntax

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,6 +78,8 @@ Remember that those using your samples may be new to SPFx, and they may not quit
 * Update the image `src` attribute according with the repository name and folder information. For example, if your sample is named `react-todo` in the `samples` folder, you should update the `src` attribute to `https://m365-visitor-stats.azurewebsites.net/sp-dev-fx-webparts/samples/react-todo`
   * Update the image `src` attribute according with the repository name and folder information.
 
+> **⚠️ IMPORTANT:** The automated validation bot checks for an `<img>` HTML element in your README. Using Markdown image syntax like `![Visitor count](...)` will trigger a validation **warning** and may delay your PR. Always use the `<img>` tag format shown in the template above.
+
 #### Contributors
 
 * Make sure to list yourself as a contributor by adding a bullet to the **Contributors** list.


### PR DESCRIPTION
### Description

The automated PR validation bot checks for an `<img>` HTML element when validating the 'README.md contains visitor stat image' criterion. Using Markdown image syntax (`![alt](url)`) triggers a warning instead of passing validation.

This PR adds a clear warning in the CONTRIBUTING.md to help contributors avoid this common pitfall.

### Changes

- Added a highlighted warning box in the `Visitor stats image` section explaining that the validation bot requires an `<img>` HTML element and that Markdown image syntax will trigger a warning

### Type of change

- [x] Documentation update

### How was this tested?

The change is a documentation-only update to CONTRIBUTING.md.