### PR TITLE
Fix future-dated sample metadata in react-knowledge-source-health

### DIFF
--- a/samples/react-knowledge-source-health/assets/sample.json
+++ b/samples/react-knowledge-source-health/assets/sample.json
@@ -9,8 +9,8 @@
     "longDescription": [
       "A SharePoint Framework web part that audits a site's document libraries against the documented constraints of Copilot Studio knowledge sources, and flags the content that will silently fail to ground."
     ],
-    "creationDateTime": "2026-12-25",
-    "updateDateTime": "2026-12-31",
+    "creationDateTime": "2026-08-15",
+    "updateDateTime": "2026-08-15",
     "products": [
       "SharePoint"
     ],


### PR DESCRIPTION
The `react-knowledge-source-health` sample went in with placeholder dates that are still in the future:

```json
"creationDateTime": "2026-12-25",
"updateDateTime": "2026-12-31",
```

Both are corrected to `2026-08-15`, the day the sample was submitted in #6464. That matches `react-mcp-client`, which was submitted the same day in #6465 and carries `2026-08-15` for both fields.

This only affects the sample metadata. No code or documentation changes.
